### PR TITLE
Add iOS platform support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Gemma4Swift",
-    platforms: [.macOS(.v15)],
+    platforms: [.macOS(.v15), .iOS(.v17)],
     products: [
         .library(name: "Gemma4Swift", targets: ["Gemma4Swift"]),
         .executable(name: "gemma4-cli", targets: ["Gemma4CLI"]),

--- a/Sources/Gemma4Swift/Pipeline/Gemma4ModelCache.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4ModelCache.swift
@@ -79,7 +79,8 @@ public enum Gemma4ModelCache {
         paths.append(customPath)
 
         // Cache HuggingFace par defaut: ~/.cache/huggingface/hub/models--{org}--{model}/snapshots/*
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+        // homeDirectoryForCurrentUser n'est pas dispo sur iOS — utiliser NSHomeDirectory()
+        let homeDir = URL(fileURLWithPath: NSHomeDirectory())
         let modelFolder = "models--\(modelId.replacingOccurrences(of: "/", with: "--"))"
         let hfSnapshotsDir = homeDir
             .appendingPathComponent(".cache/huggingface/hub")

--- a/Sources/Gemma4Swift/Pipeline/ImageProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/ImageProcessor.swift
@@ -51,7 +51,6 @@ public enum Gemma4ImageProcessor {
         // Calculer la taille cible (aspect-ratio preserving, divisible par 48)
         let divisor = patchSize * poolingKernelSize // 48
         let maxPatches = maxSoftTokens * poolingKernelSize * poolingKernelSize // 2520
-        let maxPixels = maxPatches * patchSize * patchSize // ~645K
 
         let origW = Float(image.width)
         let origH = Float(image.height)

--- a/Sources/Gemma4Swift/Pipeline/ImageProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/ImageProcessor.swift
@@ -1,6 +1,10 @@
 // Processeur d'image pour Gemma 4 — resize aspect-ratio preserving + normalisation
 
+#if canImport(AppKit)
 import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
 import CoreGraphics
 import Foundation
 import MLX
@@ -21,10 +25,18 @@ public enum Gemma4ImageProcessor {
         patchSize: Int = 16,
         poolingKernelSize: Int = 3
     ) throws -> MLXArray {
+        #if canImport(AppKit)
         guard let nsImage = NSImage(contentsOf: url),
               let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             throw ImageProcessingError.cannotLoadImage(url.path)
         }
+        #elseif canImport(UIKit)
+        guard let data = try? Data(contentsOf: url),
+              let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else {
+            throw ImageProcessingError.cannotLoadImage(url.path)
+        }
+        #endif
 
         return try processImage(cgImage, maxSoftTokens: maxSoftTokens, patchSize: patchSize, poolingKernelSize: poolingKernelSize)
     }

--- a/Tests/Gemma4SwiftTests/ImageProcessorTests.swift
+++ b/Tests/Gemma4SwiftTests/ImageProcessorTests.swift
@@ -1,0 +1,112 @@
+// Tests pour Gemma4ImageProcessor — couverture cross-platform (macOS + iOS)
+
+import CoreGraphics
+import Foundation
+import MLX
+import Testing
+
+@testable import Gemma4Swift
+
+@Suite("ImageProcessor Tests")
+struct ImageProcessorTests {
+
+    /// Cree un CGImage synthetique de taille donnee (rouge uni)
+    private func makeTestCGImage(width: Int, height: Int) -> CGImage {
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel * width
+        var pixelData = [UInt8](repeating: 0, count: height * bytesPerRow)
+        // Remplir en rouge
+        for i in 0 ..< width * height {
+            pixelData[i * 4] = 255     // R
+            pixelData[i * 4 + 1] = 0   // G
+            pixelData[i * 4 + 2] = 0   // B
+            pixelData[i * 4 + 3] = 255 // A
+        }
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(
+            data: &pixelData,
+            width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        )!
+        return context.makeImage()!
+    }
+
+    @Test("processImage retourne [1, 3, H, W] avec dimensions divisibles par 48")
+    func testOutputShape() throws {
+        let cgImage = makeTestCGImage(width: 640, height: 480)
+        let result = try Gemma4ImageProcessor.processImage(cgImage)
+
+        #expect(result.ndim == 4)
+        #expect(result.dim(0) == 1)
+        #expect(result.dim(1) == 3) // RGB channels
+        #expect(result.dim(2) % 48 == 0) // H divisible par 48
+        #expect(result.dim(3) % 48 == 0) // W divisible par 48
+    }
+
+    @Test("Les valeurs sont normalisees entre 0 et 1")
+    func testValueRange() throws {
+        let cgImage = makeTestCGImage(width: 200, height: 200)
+        let result = try Gemma4ImageProcessor.processImage(cgImage)
+
+        let minVal = result.min().item(Float.self)
+        let maxVal = result.max().item(Float.self)
+        #expect(minVal >= 0.0)
+        #expect(maxVal <= 1.0)
+    }
+
+    @Test("Le nombre de patches respecte le budget maxSoftTokens")
+    func testPatchBudget() throws {
+        let cgImage = makeTestCGImage(width: 1920, height: 1080)
+        let maxSoftTokens = 280
+        let patchSize = 16
+        let poolingKernelSize = 3
+
+        let result = try Gemma4ImageProcessor.processImage(
+            cgImage, maxSoftTokens: maxSoftTokens, patchSize: patchSize, poolingKernelSize: poolingKernelSize
+        )
+
+        let h = result.dim(2)
+        let w = result.dim(3)
+        let numPatches = (w / patchSize) * (h / patchSize)
+        let maxPatches = maxSoftTokens * poolingKernelSize * poolingKernelSize
+        #expect(numPatches <= maxPatches)
+    }
+
+    @Test("Image carree produit une sortie carree")
+    func testSquareImage() throws {
+        let cgImage = makeTestCGImage(width: 512, height: 512)
+        let result = try Gemma4ImageProcessor.processImage(cgImage)
+
+        #expect(result.dim(2) == result.dim(3))
+    }
+
+    @Test("Petite image (< 48px) produit quand meme une sortie minimale 48x48")
+    func testSmallImage() throws {
+        let cgImage = makeTestCGImage(width: 32, height: 32)
+        let result = try Gemma4ImageProcessor.processImage(cgImage)
+
+        #expect(result.dim(2) >= 48)
+        #expect(result.dim(3) >= 48)
+    }
+
+    @Test("processImage avec URL invalide lance une erreur")
+    func testInvalidURL() throws {
+        let badURL = URL(fileURLWithPath: "/nonexistent/image.png")
+        #expect(throws: ImageProcessingError.self) {
+            try Gemma4ImageProcessor.processImage(url: badURL)
+        }
+    }
+
+    @Test("Differents maxSoftTokens produisent des tailles differentes")
+    func testDifferentTokenBudgets() throws {
+        let cgImage = makeTestCGImage(width: 1024, height: 768)
+        let result280 = try Gemma4ImageProcessor.processImage(cgImage, maxSoftTokens: 280)
+        let result70 = try Gemma4ImageProcessor.processImage(cgImage, maxSoftTokens: 70)
+
+        let area280 = result280.dim(2) * result280.dim(3)
+        let area70 = result70.dim(2) * result70.dim(3)
+        #expect(area280 >= area70)
+    }
+}

--- a/Tests/Gemma4SwiftTests/ImageProcessorTests.swift
+++ b/Tests/Gemma4SwiftTests/ImageProcessorTests.swift
@@ -107,6 +107,6 @@ struct ImageProcessorTests {
 
         let area280 = result280.dim(2) * result280.dim(3)
         let area70 = result70.dim(2) * result70.dim(3)
-        #expect(area280 >= area70)
+        #expect(area280 > area70)
     }
 }


### PR DESCRIPTION
## Summary
- Add `.iOS(.v17)` platform to `Package.swift`, enabling the `Gemma4Swift` library to be used in iOS apps (iPhone 15 Pro+, iPad M1+)
- Replace `AppKit`-only image loading with `#if canImport(AppKit)` / `#if canImport(UIKit)` conditional compilation in `ImageProcessor.swift`
- Fix `Gemma4ModelCache` to use `NSHomeDirectory()` instead of `homeDirectoryForCurrentUser` (unavailable on iOS)
- Add 7 new `ImageProcessor` tests covering output shape, normalization, patch budget, edge cases

## What's NOT changed
- The CLI target (`gemma4-cli`) remains macOS-only — SPM naturally excludes executable targets for iOS
- All existing macOS behavior is preserved (no breaking changes)
- Audio/Video processors already use iOS-compatible APIs (AVFoundation, Accelerate)

## Test plan
- [x] macOS build passes (`xcodebuild -scheme gemma4-cli`)
- [x] iOS build passes (`xcodebuild -scheme Gemma4Swift -destination "generic/platform=iOS"`)
- [x] All 61+ tests pass (54 XCTest + 7+ Swift Testing)
- [ ] Manual: integrate `Gemma4Swift` in an iOS app project and load a model

🤖 Generated with [Claude Code](https://claude.com/claude-code)