### PR TITLE
Add LoRA adapter API on Pipeline + fix missing @Test

### DIFF
--- a/Sources/Gemma4Swift/Pipeline/Gemma4Pipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4Pipeline.swift
@@ -243,6 +243,20 @@ public final class Gemma4Pipeline: @unchecked Sendable {
         state = .ready
     }
 
+    // MARK: - LoRA Adapters
+
+    /// Charge un adapter LoRA et l'applique au modele
+    public func loadAdapter(from directory: URL) async throws {
+        guard let container else { throw Gemma4PipelineError.modelNotLoaded }
+        try await Gemma4LoRAInference.loadAdapter(into: container, from: directory)
+    }
+
+    /// Fuse un adapter LoRA dans les poids du modele (permanent, meilleures perfs d'inference)
+    public func fuseAdapter(from directory: URL) async throws {
+        guard let container else { throw Gemma4PipelineError.modelNotLoaded }
+        try await Gemma4LoRAInference.fuseAdapter(into: container, from: directory)
+    }
+
     /// Decharge le modele
     public func unload() {
         container = nil

--- a/Tests/Gemma4SwiftTests/DownloadIntegrationTests.swift
+++ b/Tests/Gemma4SwiftTests/DownloadIntegrationTests.swift
@@ -199,6 +199,7 @@ struct DownloadManagerTests {
     }
 
 
+    @Test("retry creates a new task")
     @MainActor
     func retryCreatesNew() async {
         let manager = Gemma4DownloadManager.shared


### PR DESCRIPTION
## Summary
- Expose `loadAdapter(from:)` and `fuseAdapter(from:)` on `Gemma4Pipeline` so SwiftUI apps can load/fuse LoRA adapters without needing access to the private `ModelContainer`
- Add missing `@Test` attribute on `retryCreatesNew()` from PR #21 — the test was silently skipped by Swift Testing

## Test plan
- [x] 88/88 tests pass
- [x] `retryCreatesNew` now discovered and executed
- [x] Build succeeds (Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)