### PR TITLE
feat: Gemma 4 Assistant MTP — drafter inference + fine-tuning (validated +13pp acceptance)

### DIFF
--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -44,7 +44,7 @@ struct Gemma4CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gemma4-cli",
         abstract: "Inference Gemma 4 via MLX Swift",
-        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self],
+        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self, MtpDiagVerify.self],
         defaultSubcommand: Generate.self
     )
 }

--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -44,7 +44,7 @@ struct Gemma4CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gemma4-cli",
         abstract: "Inference Gemma 4 via MLX Swift",
-        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self, MtpDiagVerify.self],
+        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self, MtpDiagVerify.self, MtpTrain.self],
         defaultSubcommand: Generate.self
     )
 }

--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -44,7 +44,7 @@ struct Gemma4CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gemma4-cli",
         abstract: "Inference Gemma 4 via MLX Swift",
-        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self],
+        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self],
         defaultSubcommand: Generate.self
     )
 }

--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -6,6 +6,7 @@ import Gemma4Swift
 import MLX
 import MLXLMCommon
 import MLXLLM
+import MLXNN
 import Tokenizers
 
 // MARK: - Helpers
@@ -385,6 +386,18 @@ struct Chat: AsyncParsableCommand {
     @Option(name: .long, help: "Max tokens par reponse")
     var maxTokens: Int = 1024
 
+    @Option(name: .customLong("draft-model"), help: "Repo HF d'un drafter Assistant pour speculative decoding (greedy uniquement)")
+    var draftModel: String?
+
+    @Option(name: .long, help: "Chemin local vers les poids du drafter (override --draft-model)")
+    var drafterPath: String?
+
+    @Option(name: .long, help: "Block size MTP")
+    var blockSize: Int = 4
+
+    @Flag(name: .long, help: "Bypass MaskedEmbedder a l'inference (drafter fine-tune)")
+    var fullLmHead: Bool = false
+
     func run() async throws {
         await Gemma4Registration.register()
         warnIfLowRAM(modelId: model)
@@ -397,6 +410,42 @@ struct Chat: AsyncParsableCommand {
         let container = try await loadLocalModel(path: path)
         print("Modele pret.")
 
+        // Path MTP: charge drafter, override les poids si fourni, configure pipeline
+        if let drafterRepo = draftModel {
+            print("Mode MTP active (greedy)")
+            let drafter = try await loadDrafter(repo: drafterRepo, hfToken: hfToken)
+            if let weightPath = drafterPath {
+                let url = URL(fileURLWithPath: weightPath)
+                var rawWeights: [String: MLXArray] = [:]
+                let urls: [URL]
+                var isDir: ObjCBool = false
+                FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+                if isDir.boolValue {
+                    urls = try FileManager.default
+                        .contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+                        .filter { $0.pathExtension == "safetensors" }
+                } else {
+                    urls = [url]
+                }
+                for u in urls {
+                    for (k, v) in try MLX.loadArrays(url: u) { rawWeights[k] = v }
+                }
+                let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+                    weights: rawWeights, tieWordEmbeddings: true
+                )
+                try drafter.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
+                print("  drafter weights override: \(weightPath)")
+            }
+            drafter.useFullLMHead = fullLmHead
+            let pipeline = Gemma4MTPPipeline(target: container, drafter: drafter)
+            try await runMTPChatLoop(
+                pipeline: pipeline, container: container,
+                system: system, blockSize: blockSize, maxTokens: maxTokens
+            )
+            return
+        }
+
+        // Path standard (sans MTP)
         let params = GenerateParameters(
             maxTokens: maxTokens,
             temperature: temperature,
@@ -423,6 +472,51 @@ struct Chat: AsyncParsableCommand {
 
         print("Au revoir!")
     }
+}
+
+/// Chat loop multi-turn pour le path MTP. Maintient l'historique des messages,
+/// re-tokenise le contexte complet a chaque tour via le chat template.
+private func runMTPChatLoop(
+    pipeline: Gemma4MTPPipeline,
+    container: ModelContainer,
+    system: String,
+    blockSize: Int,
+    maxTokens: Int
+) async throws {
+    var history: [[String: String]] = [["role": "system", "content": system]]
+    print("\nChat Gemma 4 + MTP (tapez 'quit' pour quitter)\n")
+
+    while true {
+        print("Vous> ", terminator: "")
+        fflush(stdout)
+        guard let input = readLine(), !input.isEmpty else { continue }
+        if input.lowercased() == "quit" || input.lowercased() == "exit" { break }
+
+        history.append(["role": "user", "content": input])
+
+        // Tokeniser l'historique complet via le chat template
+        let messages = history
+        let tokenIds: [Int] = try await container.perform { context -> [Int] in
+            try context.tokenizer.applyChatTemplate(messages: messages)
+        }
+
+        print("Gemma> ", terminator: "")
+        var assistantResponse = ""
+        let stream = await pipeline.mtpStreamFromTokens(
+            tokenIds: tokenIds, blockSize: blockSize, maxTokens: maxTokens
+        )
+        for try await piece in stream {
+            print(piece, terminator: "")
+            fflush(stdout)
+            assistantResponse += piece
+        }
+        print("\n")
+
+        // Append la reponse a l'historique pour le tour suivant
+        history.append(["role": "assistant", "content": assistantResponse])
+    }
+
+    print("Au revoir!")
 }
 
 // MARK: - Describe (multimodal: image, audio, video)

--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -262,6 +262,12 @@ struct Generate: AsyncParsableCommand {
     @Option(name: .long, help: "Nombre maximum de tokens")
     var maxTokens: Int = 512
 
+    @Option(name: .customLong("draft-model"), help: "Repo HF d'un drafter Assistant pour speculative decoding (e.g. google/gemma-4-E2B-it-assistant). Active MTP, requiert temperature=0.")
+    var draftModel: String?
+
+    @Option(name: .long, help: "Block size MTP (drafter genere blockSize-1 tokens par round)")
+    var blockSize: Int = 4
+
     @Argument(help: "Le prompt utilisateur")
     var prompt: String
 
@@ -295,8 +301,38 @@ struct Generate: AsyncParsableCommand {
         print("Systeme: \(system)")
         print("Prompt: \(prompt)")
         print("Temperature: \(temperature), Max tokens: \(maxTokens)")
+        if let drafter = draftModel {
+            print("Drafter MTP: \(drafter), block_size=\(blockSize)")
+        }
         print("---")
 
+        let startGen = Date()
+        var tokenCount = 0
+
+        if let drafterRepo = draftModel {
+            // Path MTP: load drafter, run via Gemma4MTPPipeline
+            let drafter = try await loadDrafter(repo: drafterRepo, hfToken: hfToken)
+            let pipeline = Gemma4MTPPipeline(target: container, drafter: drafter)
+            let stream = await pipeline.mtpStream(
+                prompt: prompt, blockSize: blockSize, maxTokens: maxTokens
+            )
+            for try await piece in stream {
+                print(piece, terminator: "")
+                fflush(stdout)
+                tokenCount += 1
+            }
+            let genTime = Date().timeIntervalSince(startGen)
+            let stats = await pipeline.lastStats
+            let tokPerSec = genTime > 0 ? Double(stats.emittedTokens) / genTime : 0
+            print("\n\n--- Stats MTP ---")
+            print("Tokens emis: \(stats.emittedTokens)")
+            print("Rounds: \(stats.rounds), drafts acceptes: \(stats.acceptedDrafts)/\(stats.totalDrafts) (\(Int(stats.acceptRate * 100))%)")
+            print("Temps: \(String(format: "%.2f", genTime))s = \(String(format: "%.1f", tokPerSec)) tok/s")
+            print("GPU pic: \(MLX.GPU.peakMemory / (1024 * 1024)) Mo")
+            return
+        }
+
+        // Path standard (sans MTP)
         let params = GenerateParameters(
             maxTokens: maxTokens,
             temperature: temperature,
@@ -304,9 +340,6 @@ struct Generate: AsyncParsableCommand {
         )
 
         let session = ChatSession(container, instructions: system, generateParameters: params)
-
-        let startGen = Date()
-        var tokenCount = 0
 
         // Streaming token par token
         let stream = session.streamResponse(to: prompt)

--- a/Sources/Gemma4CLI/MtpDiagVerifyCommand.swift
+++ b/Sources/Gemma4CLI/MtpDiagVerifyCommand.swift
@@ -1,0 +1,180 @@
+// Diagnostic: compare hidden states / logits produits par deux modes equivalents
+// pour le MEME modele et la MEME sequence de tokens:
+//   1. Sequential: autoregressive decode token-par-token (N forwards de longueur 1)
+//   2. Parallel  : un forward de longueur N
+//
+// Si les hidden states divergent significativement, le verify forward du target
+// produit un etat different du sequential equivalent, ce qui expliquerait pourquoi
+// le drafter MTP (entraine sur sequential decode du target) drift sur les rounds.
+
+import ArgumentParser
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Gemma4Swift
+
+struct MtpDiagVerify: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mtp-diag-verify",
+        abstract: "Diagnostic: hidden states sequential vs parallel verify (target seul)"
+    )
+
+    @Option(name: .long, help: "Repo HuggingFace du target (BF16 recommande)")
+    var target: String = "mlx-community/gemma-4-e2b-it-bf16"
+
+    @Option(name: .long, help: "Prompt utilisateur")
+    var prompt: String = "Tell me a one-line fact about the moon."
+
+    @Option(name: .long, help: "Nombre de tokens a comparer apres le prompt")
+    var nTokens: Int = 8
+
+    @Option(name: .long, help: "Token HuggingFace")
+    var hfToken: String?
+
+    func run() async throws {
+        print("[mtp-diag-verify] target=\(target)")
+        print("[mtp-diag-verify] n_tokens=\(nTokens)")
+        print()
+
+        let targetDir = try await Gemma4ModelDownloader.download(
+            modelId: target, token: resolveHFToken(hfToken)
+        ) { _ in }
+
+        await Gemma4Registration.register(multimodal: false)
+        let container = try await loadModelContainer(from: targetDir, using: Gemma4TokenizerLoader())
+
+        let n = nTokens
+        let userPrompt = prompt
+
+        try await container.perform { context in
+            guard let llm = context.model as? Gemma4LLMModel else {
+                fatalError("Expected Gemma4LLMModel, got \(type(of: context.model))")
+            }
+            let langModel = llm.languageModel
+
+            // Tokenize avec chat template
+            let messages: [[String: String]] = [["role": "user", "content": userPrompt]]
+            let promptIds = try context.tokenizer.applyChatTemplate(messages: messages)
+            let promptArr = MLXArray(promptIds.map { Int32($0) }).reshaped(1, -1)
+            let promptLen = promptArr.dim(1)
+            print("prompt_len = \(promptLen)")
+
+            // ==============================================================
+            // MODE A: Sequential autoregressive decode (greedy, N steps)
+            // ==============================================================
+            print("\n=== Mode A: SEQUENTIAL autoregressive decode ===")
+            let cacheSeq = langModel.makeCache()
+            let cacheSeqArr = cacheSeq.map { $0 as KVCache? }
+
+            // Prefill
+            let prefillSeq = langModel.forwardWithIntermediates(
+                inputs: promptArr, cache: cacheSeqArr
+            )
+            eval(prefillSeq.logits, prefillSeq.preNormHiddenStates)
+
+            // First bonus
+            let firstBonusSeq = argMax(prefillSeq.logits[0, promptLen - 1, 0...], axis: -1).item(Int32.self)
+            print("first_bonus = \(firstBonusSeq) -> \((try? context.tokenizer.decode(tokenIds: [Int(firstBonusSeq)])) ?? "?")")
+
+            // Sequential N steps
+            var seqTokens: [Int32] = [firstBonusSeq]
+            var seqHiddens: [MLXArray] = []
+            var seqLogits: [MLXArray] = []
+            var lastTok = firstBonusSeq
+            for step in 0 ..< n {
+                let stepIn = MLXArray([lastTok]).reshaped(1, 1)
+                let out = langModel.forwardWithIntermediates(inputs: stepIn, cache: cacheSeqArr)
+                eval(out.logits, out.preNormHiddenStates)
+                seqHiddens.append(out.preNormHiddenStates[0..., 0..<1, 0...])
+                seqLogits.append(out.logits[0..., 0..<1, 0...])
+                let nextTok = argMax(out.logits[0, 0, 0...], axis: -1).item(Int32.self)
+                seqTokens.append(nextTok)
+                lastTok = nextTok
+                print("  step \(step): in=\(seqTokens[step]) → out=\(nextTok) (\((try? context.tokenizer.decode(tokenIds: [Int(nextTok)])) ?? "?"))")
+            }
+
+            // ==============================================================
+            // MODE B: Parallel multi-token decode (le mode utilise par MTP verify)
+            // ==============================================================
+            print("\n=== Mode B: PARALLEL multi-token verify ===")
+            let cachePar = langModel.makeCache()
+            let cacheParArr = cachePar.map { $0 as KVCache? }
+
+            // Re-prefill
+            _ = langModel.forwardWithIntermediates(inputs: promptArr, cache: cacheParArr)
+
+            // Input parallele = [first_bonus, then N-1 tokens generated sequentially]
+            // (= ce que le verify recoit de cote MTP)
+            let parInput = MLXArray(seqTokens.prefix(n).map { $0 }).reshaped(1, n)
+            print("  input parallel = \(Array(seqTokens.prefix(n)))")
+
+            let outPar = langModel.forwardWithIntermediates(inputs: parInput, cache: cacheParArr)
+            eval(outPar.logits, outPar.preNormHiddenStates)
+
+            // ==============================================================
+            // COMPARISON
+            // ==============================================================
+            print("\n=== COMPARISON: seqHiddens[i] vs outPar.preNormHiddenStates[:, i, :] ===")
+            print("(diff non-zero indique parallel verify produit un etat different du sequential)")
+            print()
+            for i in 0 ..< n {
+                let seqH = seqHiddens[i]               // [1, 1, hidden]
+                let parH = outPar.preNormHiddenStates[0..., i..<(i+1), 0...]  // [1, 1, hidden]
+
+                let diff = abs(seqH - parH)
+                let maxDiff = diff.max().item(Float.self)
+                let meanDiff = diff.mean().item(Float.self)
+                let normSeq = sqrt((seqH * seqH).sum().item(Float.self))
+                let normPar = sqrt((parH * parH).sum().item(Float.self))
+                let cosSim: Float = {
+                    let dot = (seqH * parH).sum().item(Float.self)
+                    return dot / (normSeq * normPar + 1e-9)
+                }()
+
+                // Compare logits aussi
+                let seqL = seqLogits[i]
+                let parL = outPar.logits[0..., i..<(i+1), 0...]
+                let seqArgmax = argMax(seqL[0, 0, 0...], axis: -1).item(Int32.self)
+                let parArgmax = argMax(parL[0, 0, 0...], axis: -1).item(Int32.self)
+                let argmaxMatch = seqArgmax == parArgmax ? "OK" : "DIFF"
+
+                print(String(format: "  pos %d: hidden max_diff=%.4e mean_diff=%.4e cosSim=%.6f  argmax seq=%d par=%d [%@]",
+                             i, maxDiff, meanDiff, cosSim, seqArgmax, parArgmax, argmaxMatch))
+            }
+
+            // Also compare hidden state norms
+            print("\n=== HIDDEN NORMS (sanity) ===")
+            for i in 0 ..< n {
+                let seqH = seqHiddens[i]
+                let parH = outPar.preNormHiddenStates[0..., i..<(i+1), 0...]
+                let normSeq = sqrt((seqH * seqH).sum().item(Float.self))
+                let normPar = sqrt((parH * parH).sum().item(Float.self))
+                print(String(format: "  pos %d: |seq|=%.4f  |par|=%.4f", i, normSeq, normPar))
+            }
+
+            // ==============================================================
+            // MODE C: parallel forward avec L=1 (degenerate, equivalent au sequential)
+            // Si meme avec L=1 le hidden differe du sequential, le bug est ailleurs.
+            // ==============================================================
+            print("\n=== Mode C: PARALLEL forward avec L=1 (chaque token un par un en mode parallele) ===")
+            let cacheC = langModel.makeCache()
+            let cacheCArr = cacheC.map { $0 as KVCache? }
+            _ = langModel.forwardWithIntermediates(inputs: promptArr, cache: cacheCArr)
+
+            for i in 0 ..< n {
+                let stepIn = MLXArray([seqTokens[i]]).reshaped(1, 1)
+                let outC = langModel.forwardWithIntermediates(inputs: stepIn, cache: cacheCArr)
+                eval(outC.preNormHiddenStates)
+                let cH = outC.preNormHiddenStates[0..., 0..<1, 0...]
+                let seqH = seqHiddens[i]
+                let diff = abs(cH - seqH)
+                let maxDiff = diff.max().item(Float.self)
+                let meanDiff = diff.mean().item(Float.self)
+                print(String(format: "  pos %d (L=1 par): max_diff_vs_seq=%.4e mean_diff=%.4e", i, maxDiff, meanDiff))
+            }
+        }
+
+        print("\n[mtp-diag-verify] DONE")
+    }
+}

--- a/Sources/Gemma4CLI/MtpDrafterLoader.swift
+++ b/Sources/Gemma4CLI/MtpDrafterLoader.swift
@@ -1,0 +1,45 @@
+// Helper de chargement du drafter Assistant pour les commandes CLI qui supportent
+// `--draft-model` (Generate, Chat, Describe).
+
+import Foundation
+import MLX
+import MLXNN
+import Gemma4Swift
+
+/// Telecharge si necessaire et charge le drafter Assistant. Verifie le mappage
+/// des poids via `update(parameters:verify:.all)`.
+public func loadDrafter(
+    repo: String,
+    hfToken: String?
+) async throws -> Gemma4AssistantDraftModel {
+    print("Chargement du drafter \(repo)...")
+    let drafterDir = try await Gemma4ModelDownloader.download(
+        modelId: repo, token: resolveHFToken(hfToken)
+    ) { p in
+        print("\r  drafter: \(Int(p.fraction * 100))% — \(p.currentFile)              ", terminator: "")
+        fflush(stdout)
+    }
+    print()
+
+    let cfgData = try Data(contentsOf: drafterDir.appendingPathComponent("config.json"))
+    let cfg = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: cfgData)
+    let drafter = Gemma4AssistantDraftModel(cfg)
+
+    let safetensors = try FileManager.default
+        .contentsOfDirectory(at: drafterDir, includingPropertiesForKeys: nil)
+        .filter { $0.pathExtension == "safetensors" }
+        .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+    var raw: [String: MLXArray] = [:]
+    for url in safetensors {
+        for (k, v) in try MLX.loadArrays(url: url) {
+            raw[k] = v
+        }
+    }
+    let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+        weights: raw, tieWordEmbeddings: cfg.tieWordEmbeddings
+    )
+    try drafter.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
+    print("  drafter: \(sanitized.count) tenseurs charges (hidden=\(cfg.textConfig.hiddenSize), backbone=\(cfg.backboneHiddenSize))")
+    return drafter
+}

--- a/Sources/Gemma4CLI/MtpForwardCommand.swift
+++ b/Sources/Gemma4CLI/MtpForwardCommand.swift
@@ -133,7 +133,7 @@ struct MtpForward: AsyncParsableCommand {
 
             // ---- Target prefill avec collecte des intermediates ----
             let prefillOut = langModel.forwardWithIntermediates(inputs: inputArr)
-            eval(prefillOut.logits, prefillOut.hiddenStates)
+            eval(prefillOut.logits, prefillOut.preNormHiddenStates)
 
             // Last position logits -> first bonus
             let lastLogits = prefillOut.logits[0, promptLen - 1, 0...]
@@ -142,7 +142,7 @@ struct MtpForward: AsyncParsableCommand {
             print("  target first bonus = \(firstBonus) -> \(firstBonusStr.debugDescription)")
 
             // Last hidden state [1, 1, hidden]
-            let lastHidden = prefillOut.hiddenStates[0..., (promptLen - 1) ..< promptLen, 0...]
+            let lastHidden = prefillOut.preNormHiddenStates[0..., (promptLen - 1) ..< promptLen, 0...]
             print("  last hidden shape = \(lastHidden.shape)")
 
             // ---- Extraire shared K/V (derniere couche concrete full + sliding) ----

--- a/Sources/Gemma4CLI/MtpForwardCommand.swift
+++ b/Sources/Gemma4CLI/MtpForwardCommand.swift
@@ -1,0 +1,229 @@
+// Forward de bout en bout: target prefill -> drafter draft. Permet de valider que
+// le drafter produit des tokens senses sur des hidden states / shared K/V REELS
+// (vs synthetique random comme dans mtp-smoke).
+//
+// Usage:
+//   gemma4-cli mtp-forward --target mlx-community/gemma-4-e2b-it-4bit \
+//     --drafter google/gemma-4-E2B-it-assistant \
+//     --prompt "Bonjour, comment vas-" \
+//     --block-size 4
+
+import ArgumentParser
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Gemma4Swift
+
+struct MtpForward: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mtp-forward",
+        abstract: "Target prefill + drafter forward sur prompt reel (validation Jalon B)"
+    )
+
+    @Option(name: .long, help: "Repo HuggingFace du target (e.g. mlx-community/gemma-4-e2b-it-4bit)")
+    var target: String = "mlx-community/gemma-4-e2b-it-bf16"
+
+    @Option(name: .long, help: "Repo HuggingFace du drafter Assistant")
+    var drafter: String = "google/gemma-4-E2B-it-assistant"
+
+    @Option(name: .long, help: "Prompt a faire prefiller par le target")
+    var prompt: String = "Tell me a one-line fact about the moon."
+
+    @Option(name: .long, help: "Block size pour le draft (drafter genere blockSize-1 tokens)")
+    var blockSize: Int = 4
+
+    @Flag(name: .long, help: "Skip le chat template (utilise raw encode au lieu de applyChatTemplate)")
+    var raw: Bool = false
+
+    @Option(name: .long, help: "Token HuggingFace")
+    var hfToken: String?
+
+    func run() async throws {
+        print("[mtp-forward] target=\(target)")
+        print("[mtp-forward] drafter=\(drafter)")
+        print("[mtp-forward] prompt=\(prompt.debugDescription)")
+        print("[mtp-forward] block_size=\(blockSize)")
+        print()
+
+        // ============================================================
+        // 1. Telecharger les deux modeles
+        // ============================================================
+        print("[1/5] Download target...")
+        let targetDir = try await Gemma4ModelDownloader.download(
+            modelId: target, token: resolveHFToken(hfToken)
+        ) { p in
+            print("\r  \(Int(p.fraction * 100))% — \(p.currentFile)              ", terminator: "")
+            fflush(stdout)
+        }
+        print("\n  -> \(targetDir.path)")
+
+        print("[2/5] Download drafter...")
+        let drafterDir = try await Gemma4ModelDownloader.download(
+            modelId: drafter, token: resolveHFToken(hfToken)
+        ) { p in
+            print("\r  \(Int(p.fraction * 100))% — \(p.currentFile)              ", terminator: "")
+            fflush(stdout)
+        }
+        print("\n  -> \(drafterDir.path)")
+
+        // ============================================================
+        // 2. Charger le target via loadModelContainer (text-only)
+        // ============================================================
+        print("[3/5] Load target (text-only)...")
+        await Gemma4Registration.register(multimodal: false)
+        let container = try await loadModelContainer(from: targetDir, using: Gemma4TokenizerLoader())
+        print("  target loaded")
+
+        // ============================================================
+        // 3. Charger le drafter manuellement
+        // ============================================================
+        print("[4/5] Load drafter...")
+        let drafterConfigData = try Data(contentsOf: drafterDir.appendingPathComponent("config.json"))
+        let drafterConfig = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: drafterConfigData)
+        let drafterModel = Gemma4AssistantDraftModel(drafterConfig)
+
+        let drafterSafetensors = try FileManager.default
+            .contentsOfDirectory(at: drafterDir, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        var drafterRawWeights: [String: MLXArray] = [:]
+        for url in drafterSafetensors {
+            for (k, v) in try MLX.loadArrays(url: url) {
+                drafterRawWeights[k] = v
+            }
+        }
+        let drafterSanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: drafterRawWeights, tieWordEmbeddings: drafterConfig.tieWordEmbeddings
+        )
+        try drafterModel.update(parameters: ModuleParameters.unflattened(drafterSanitized), verify: .all)
+        print("  drafter loaded (\(drafterSanitized.count) tensors)")
+        print("  drafter backbone=\(drafterConfig.backboneHiddenSize), hidden=\(drafterConfig.textConfig.hiddenSize)")
+        print()
+
+        // ============================================================
+        // 4. Forward de bout en bout dans une seule perform
+        // ============================================================
+        print("[5/5] Run target prefill + drafter draft...")
+        nonisolated(unsafe) let drafterRef = drafterModel
+        let drafterBlockSize = blockSize
+        let userPrompt = prompt
+        let useChatTemplate = !raw
+
+        try await container.perform { context in
+            guard let llm = context.model as? Gemma4LLMModel else {
+                fatalError("Expected Gemma4LLMModel, got \(type(of: context.model))")
+            }
+            let langModel = llm.languageModel
+            let textCfg = langModel.config
+
+            // ---- Tokenize ----
+            let promptIds: [Int]
+            if useChatTemplate {
+                let messages: [[String: String]] = [["role": "user", "content": userPrompt]]
+                promptIds = try context.tokenizer.applyChatTemplate(messages: messages)
+            } else {
+                promptIds = try context.tokenizer.encode(text: userPrompt)
+            }
+            let inputArr = MLXArray(promptIds.map { Int32($0) }).reshaped(1, -1)
+            let promptLen = inputArr.dim(1)
+            print("  prompt len = \(promptLen) tokens")
+            print("  first 5: \(Array(promptIds.prefix(5))), last 5: \(Array(promptIds.suffix(5)))")
+
+            // ---- Target prefill avec collecte des intermediates ----
+            let prefillOut = langModel.forwardWithIntermediates(inputs: inputArr)
+            eval(prefillOut.logits, prefillOut.hiddenStates)
+
+            // Last position logits -> first bonus
+            let lastLogits = prefillOut.logits[0, promptLen - 1, 0...]
+            let firstBonus = argMax(lastLogits, axis: -1).item(Int32.self)
+            let firstBonusStr = (try? context.tokenizer.decode(tokenIds: [Int(firstBonus)])) ?? "?"
+            print("  target first bonus = \(firstBonus) -> \(firstBonusStr.debugDescription)")
+
+            // Last hidden state [1, 1, hidden]
+            let lastHidden = prefillOut.hiddenStates[0..., (promptLen - 1) ..< promptLen, 0...]
+            print("  last hidden shape = \(lastHidden.shape)")
+
+            // ---- Extraire shared K/V (derniere couche concrete full + sliding) ----
+            let layerTypes = textCfg.resolvedLayerTypes
+            let firstSharedIdx = textCfg.firstKvSharedLayerIdx
+            let concreteTypes = Array(layerTypes.prefix(firstSharedIdx))
+            guard let lastFullIdx = concreteTypes.lastIndex(of: "full_attention"),
+                  let lastSlidingIdx = concreteTypes.lastIndex(of: "sliding_attention"),
+                  let fullKV = prefillOut.intermediates[lastFullIdx],
+                  let slidingKV = prefillOut.intermediates[lastSlidingIdx] else {
+                fatalError("Cannot extract shared K/V from intermediates (firstShared=\(firstSharedIdx))")
+            }
+            print("  shared full layer idx = \(lastFullIdx), K shape = \(fullKV.keys.shape)")
+            print("  shared sliding layer idx = \(lastSlidingIdx), K shape = \(slidingKV.keys.shape)")
+
+            let sharedKV: SharedKVStates = [
+                "full_attention": (keys: fullKV.keys, values: fullKV.values),
+                "sliding_attention": (keys: slidingKV.keys, values: slidingKV.values),
+            ]
+
+            // ---- Bind drafter au target ----
+            drafterRef.bind(target: langModel)
+            drafterRef.setSharedKV(sharedKV, kvOffset: promptLen)
+
+            // ---- Drafter draftBlock ----
+            print()
+            print("  --- Drafter draftBlock(blockSize=\(drafterBlockSize)) ---")
+            let drafts = drafterRef.draftBlock(
+                lastBonus: firstBonus,
+                hidden: lastHidden,
+                blockSize: drafterBlockSize
+            ) { logits in
+                argMax(logits, axis: -1)
+            }
+            eval(drafts)
+            let nDrafts = drafts.dim(1)
+            var draftIds: [Int32] = []
+            for i in 0 ..< nDrafts {
+                draftIds.append(drafts[0, i].item(Int32.self))
+            }
+            let draftsStr = (try? context.tokenizer.decode(tokenIds: draftIds.map(Int.init))) ?? "?"
+            print("  drafts (\(nDrafts) tokens) = \(draftIds)")
+            print("  drafts decoded = \(draftsStr.debugDescription)")
+
+            // ---- Comparaison avec target greedy autoregressive (golden) ----
+            print()
+            print("  --- Target greedy autoregressive (golden) ---")
+            // Continue le target sans drafter pour comparer
+            var targetCache = langModel.makeCache()
+            // Re-prefill pour avoir un cache utilisable
+            _ = langModel(inputs: inputArr, cache: targetCache.map { $0 as KVCache? })
+            var lastTok = firstBonus
+            var goldenIds: [Int32] = [firstBonus]
+            for _ in 1 ... nDrafts {
+                let stepIn = MLXArray([lastTok]).reshaped(1, 1)
+                let stepOut = langModel(inputs: stepIn, cache: targetCache.map { $0 as KVCache? })
+                lastTok = argMax(stepOut[0, 0, 0...], axis: -1).item(Int32.self)
+                goldenIds.append(lastTok)
+            }
+            let goldenStr = (try? context.tokenizer.decode(tokenIds: goldenIds.map(Int.init))) ?? "?"
+            print("  golden (\(goldenIds.count) tokens incl bonus) = \(goldenIds)")
+            print("  golden decoded = \(goldenStr.debugDescription)")
+
+            // Comparison
+            let goldenDrafts = Array(goldenIds.dropFirst())  // skip the bonus
+            print()
+            print("  --- Comparaison drafts vs golden ---")
+            var matches = 0
+            for i in 0 ..< nDrafts {
+                let m = draftIds[i] == goldenDrafts[i]
+                if m { matches += 1 }
+                let mark = m ? "OK" : "DIFF"
+                let dStr = (try? context.tokenizer.decode(tokenIds: [Int(draftIds[i])])) ?? "?"
+                let gStr = (try? context.tokenizer.decode(tokenIds: [Int(goldenDrafts[i])])) ?? "?"
+                print("  pos \(i): drafter=\(draftIds[i])(\(dStr.debugDescription))  golden=\(goldenDrafts[i])(\(gStr.debugDescription))  [\(mark)]")
+            }
+            print()
+            print("  -> \(matches)/\(nDrafts) drafts == target greedy")
+            print("  Note: 100% est exceptionnel (drafter ~ target). 50%+ est deja le signe d'un drafter sain.")
+        }
+
+        print("\n[mtp-forward] DONE")
+    }
+}

--- a/Sources/Gemma4CLI/MtpGenerateCommand.swift
+++ b/Sources/Gemma4CLI/MtpGenerateCommand.swift
@@ -50,6 +50,9 @@ struct MtpGenerate: AsyncParsableCommand {
     @Flag(name: .long, help: "Bypass le MaskedEmbedder a l'inference et utiliser le full lm head (necessaire si drafter est fine-tune sans toucher les centroides)")
     var fullLmHead: Bool = false
 
+    @Option(name: .long, help: "Chemin vers un adapter LoRA a appliquer au target (e.g. pour benchmark MTP avec target fine-tune)")
+    var adapterPath: String?
+
     @Option(name: .long, help: "Token HuggingFace")
     var hfToken: String?
 
@@ -81,6 +84,13 @@ struct MtpGenerate: AsyncParsableCommand {
         print("[2/3] Load target + drafter...")
         await Gemma4Registration.register(multimodal: false)
         let container = try await loadModelContainer(from: targetDir, using: Gemma4TokenizerLoader())
+
+        // Apply LoRA adapter if requested
+        if let adapter = adapterPath {
+            let adapterURL = URL(fileURLWithPath: adapter)
+            try await Gemma4LoRAInference.loadAdapter(into: container, from: adapterURL)
+            print("  LoRA adapter loaded: \(adapter)")
+        }
 
         let drafterCfgData = try Data(contentsOf: drafterDir.appendingPathComponent("config.json"))
         let drafterCfg = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: drafterCfgData)

--- a/Sources/Gemma4CLI/MtpGenerateCommand.swift
+++ b/Sources/Gemma4CLI/MtpGenerateCommand.swift
@@ -1,0 +1,164 @@
+// Generation MTP end-to-end: target + drafter, comparaison avec generation standard.
+//
+// Usage:
+//   gemma4-cli mtp-generate --target ... --drafter ... --prompt "..." --max-tokens 64
+//   gemma4-cli mtp-generate --compare      # active la comparaison cote-a-cote standard vs MTP
+//
+// Pour le mode --compare, le test d'equivalence est greedy strict: les sorties doivent
+// etre identiques. Si elles divergent, MTP a un bug.
+
+import ArgumentParser
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Gemma4Swift
+
+struct MtpGenerate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mtp-generate",
+        abstract: "Generation speculative decoding (MTP) avec equivalence greedy"
+    )
+
+    @Option(name: .long, help: "Repo HuggingFace du target (BF16 recommande)")
+    var target: String = "mlx-community/gemma-4-e2b-it-bf16"
+
+    @Option(name: .long, help: "Repo HuggingFace du drafter Assistant")
+    var drafter: String = "google/gemma-4-E2B-it-assistant"
+
+    @Option(name: .long, help: "Prompt utilisateur")
+    var prompt: String = "Tell me a one-line fact about the moon."
+
+    @Option(name: .long, help: "Block size MTP (drafter genere blockSize-1 tokens par round)")
+    var blockSize: Int = 4
+
+    @Option(name: .long, help: "Nombre maximum de tokens a generer")
+    var maxTokens: Int = 64
+
+    @Flag(name: .long, help: "Compare la sortie MTP avec la generation standard greedy (test d'equivalence)")
+    var compare: Bool = false
+
+    @Flag(name: .long, help: "Skip le chat template")
+    var raw: Bool = false
+
+    @Option(name: .long, help: "Token HuggingFace")
+    var hfToken: String?
+
+    func run() async throws {
+        print("[mtp-generate] target=\(target)")
+        print("[mtp-generate] drafter=\(drafter)")
+        print("[mtp-generate] prompt=\(prompt.debugDescription)")
+        print("[mtp-generate] block_size=\(blockSize)  max_tokens=\(maxTokens)")
+        print()
+
+        // Download
+        print("[1/3] Download...")
+        let targetDir = try await Gemma4ModelDownloader.download(
+            modelId: target, token: resolveHFToken(hfToken)
+        ) { p in
+            print("\r  target: \(Int(p.fraction * 100))% — \(p.currentFile)              ", terminator: "")
+            fflush(stdout)
+        }
+        print()
+        let drafterDir = try await Gemma4ModelDownloader.download(
+            modelId: drafter, token: resolveHFToken(hfToken)
+        ) { p in
+            print("\r  drafter: \(Int(p.fraction * 100))% — \(p.currentFile)              ", terminator: "")
+            fflush(stdout)
+        }
+        print()
+
+        // Load
+        print("[2/3] Load target + drafter...")
+        await Gemma4Registration.register(multimodal: false)
+        let container = try await loadModelContainer(from: targetDir, using: Gemma4TokenizerLoader())
+
+        let drafterCfgData = try Data(contentsOf: drafterDir.appendingPathComponent("config.json"))
+        let drafterCfg = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: drafterCfgData)
+        let drafterModel = Gemma4AssistantDraftModel(drafterCfg)
+        let drafterSafetensors = try FileManager.default
+            .contentsOfDirectory(at: drafterDir, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "safetensors" }
+        var rawWeights: [String: MLXArray] = [:]
+        for url in drafterSafetensors {
+            for (k, v) in try MLX.loadArrays(url: url) { rawWeights[k] = v }
+        }
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: rawWeights, tieWordEmbeddings: drafterCfg.tieWordEmbeddings
+        )
+        try drafterModel.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
+        print("  loaded")
+
+        // Generate via MTP pipeline
+        print()
+        print("[3/3] MTP generation...")
+        let pipeline = Gemma4MTPPipeline(target: container, drafter: drafterModel)
+        let mtpStream = await pipeline.mtpStream(
+            prompt: prompt, blockSize: blockSize, maxTokens: maxTokens, useChatTemplate: !raw
+        )
+
+        var mtpOutput = ""
+        let mtpStart = Date()
+        print("MTP> ", terminator: "")
+        fflush(stdout)
+        for try await piece in mtpStream {
+            print(piece, terminator: "")
+            fflush(stdout)
+            mtpOutput += piece
+        }
+        let mtpElapsed = Date().timeIntervalSince(mtpStart)
+        print()
+        let stats = await pipeline.lastStats
+        print()
+        print("[MTP] \(stats.emittedTokens) tokens en \(String(format: "%.2f", mtpElapsed))s = \(String(format: "%.1f", Double(stats.emittedTokens) / mtpElapsed)) tok/s")
+        print("[MTP] rounds=\(stats.rounds), drafts acceptes=\(stats.acceptedDrafts)/\(stats.totalDrafts) (\(Int(stats.acceptRate * 100))%)")
+
+        if !compare {
+            print("\n[mtp-generate] DONE")
+            return
+        }
+
+        // Comparaison: generation standard via ChatSession greedy
+        print()
+        print("[compare] Generation standard greedy pour equivalence...")
+        let stdParams = GenerateParameters(maxTokens: maxTokens, temperature: 0)
+        let session = ChatSession(container, instructions: nil, generateParameters: stdParams)
+        var stdOutput = ""
+        let stdStart = Date()
+        print("STD> ", terminator: "")
+        fflush(stdout)
+        for try await piece in session.streamResponse(to: prompt) {
+            print(piece, terminator: "")
+            fflush(stdout)
+            stdOutput += piece
+        }
+        let stdElapsed = Date().timeIntervalSince(stdStart)
+        print()
+        print()
+        print("[STD] \(stdOutput.count) chars en \(String(format: "%.2f", stdElapsed))s")
+
+        // Comparison
+        print()
+        print("=" .padding(toLength: 60, withPad: "=", startingAt: 0))
+        print("Comparaison MTP vs STD:")
+        if mtpOutput == stdOutput {
+            print("  IDENTIQUE (\(mtpOutput.count) chars)")
+            print("  Speedup: \(String(format: "%.2fx", stdElapsed / mtpElapsed))")
+        } else {
+            print("  DIFFERENT")
+            print("  MTP: \(mtpOutput.debugDescription)")
+            print("  STD: \(stdOutput.debugDescription)")
+            // Trouver le 1er point de divergence
+            let common = mtpOutput.commonPrefix(with: stdOutput).count
+            print("  Prefix commun: \(common) chars")
+            if common < mtpOutput.count {
+                let idx = mtpOutput.index(mtpOutput.startIndex, offsetBy: common)
+                print("  MTP diverge a: \(mtpOutput[idx...].prefix(40).debugDescription)")
+            }
+            if common < stdOutput.count {
+                let idx = stdOutput.index(stdOutput.startIndex, offsetBy: common)
+                print("  STD diverge a: \(stdOutput[idx...].prefix(40).debugDescription)")
+            }
+        }
+    }
+}

--- a/Sources/Gemma4CLI/MtpGenerateCommand.swift
+++ b/Sources/Gemma4CLI/MtpGenerateCommand.swift
@@ -26,6 +26,9 @@ struct MtpGenerate: AsyncParsableCommand {
     @Option(name: .long, help: "Repo HuggingFace du drafter Assistant")
     var drafter: String = "google/gemma-4-E2B-it-assistant"
 
+    @Option(name: .long, help: "Chemin vers un fichier safetensors de drafter fine-tune (override le drafter HF). Le config.json doit etre dans le meme repertoire ou hérité de --drafter.")
+    var drafterPath: String?
+
     @Option(name: .long, help: "Prompt utilisateur")
     var prompt: String = "Tell me a one-line fact about the moon."
 
@@ -43,6 +46,9 @@ struct MtpGenerate: AsyncParsableCommand {
 
     @Flag(name: .long, help: "DIAGNOSTIC: utiliser sequential verify (1 token a la fois, lent mais numeriquement equivalent au sequential decode)")
     var sequentialVerify: Bool = false
+
+    @Flag(name: .long, help: "Bypass le MaskedEmbedder a l'inference et utiliser le full lm head (necessaire si drafter est fine-tune sans toucher les centroides)")
+    var fullLmHead: Bool = false
 
     @Option(name: .long, help: "Token HuggingFace")
     var hfToken: String?
@@ -79,18 +85,38 @@ struct MtpGenerate: AsyncParsableCommand {
         let drafterCfgData = try Data(contentsOf: drafterDir.appendingPathComponent("config.json"))
         let drafterCfg = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: drafterCfgData)
         let drafterModel = Gemma4AssistantDraftModel(drafterCfg)
-        let drafterSafetensors = try FileManager.default
-            .contentsOfDirectory(at: drafterDir, includingPropertiesForKeys: nil)
-            .filter { $0.pathExtension == "safetensors" }
+
+        // Choisir source des poids: override local (drafterPath) ou HF default (drafterDir)
+        let weightURLs: [URL]
+        if let pathStr = drafterPath {
+            let pathURL = URL(fileURLWithPath: pathStr)
+            // Si c'est un fichier .safetensors, juste celui-la. Sinon repertoire.
+            var isDir: ObjCBool = false
+            FileManager.default.fileExists(atPath: pathURL.path, isDirectory: &isDir)
+            if isDir.boolValue {
+                weightURLs = try FileManager.default
+                    .contentsOfDirectory(at: pathURL, includingPropertiesForKeys: nil)
+                    .filter { $0.pathExtension == "safetensors" }
+            } else {
+                weightURLs = [pathURL]
+            }
+            print("  drafter weights from local path: \(weightURLs.map { $0.lastPathComponent })")
+        } else {
+            weightURLs = try FileManager.default
+                .contentsOfDirectory(at: drafterDir, includingPropertiesForKeys: nil)
+                .filter { $0.pathExtension == "safetensors" }
+        }
+
         var rawWeights: [String: MLXArray] = [:]
-        for url in drafterSafetensors {
+        for url in weightURLs {
             for (k, v) in try MLX.loadArrays(url: url) { rawWeights[k] = v }
         }
         let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
             weights: rawWeights, tieWordEmbeddings: drafterCfg.tieWordEmbeddings
         )
         try drafterModel.update(parameters: ModuleParameters.unflattened(sanitized), verify: .all)
-        print("  loaded")
+        drafterModel.useFullLMHead = fullLmHead
+        print("  loaded\(fullLmHead ? " (full lm head)" : " (masked_embedding)")")
 
         // Generate via MTP pipeline
         print()

--- a/Sources/Gemma4CLI/MtpGenerateCommand.swift
+++ b/Sources/Gemma4CLI/MtpGenerateCommand.swift
@@ -41,6 +41,9 @@ struct MtpGenerate: AsyncParsableCommand {
     @Flag(name: .long, help: "Skip le chat template")
     var raw: Bool = false
 
+    @Flag(name: .long, help: "DIAGNOSTIC: utiliser sequential verify (1 token a la fois, lent mais numeriquement equivalent au sequential decode)")
+    var sequentialVerify: Bool = false
+
     @Option(name: .long, help: "Token HuggingFace")
     var hfToken: String?
 
@@ -94,7 +97,8 @@ struct MtpGenerate: AsyncParsableCommand {
         print("[3/3] MTP generation...")
         let pipeline = Gemma4MTPPipeline(target: container, drafter: drafterModel)
         let mtpStream = await pipeline.mtpStream(
-            prompt: prompt, blockSize: blockSize, maxTokens: maxTokens, useChatTemplate: !raw
+            prompt: prompt, blockSize: blockSize, maxTokens: maxTokens,
+            useChatTemplate: !raw, sequentialVerify: sequentialVerify
         )
 
         var mtpOutput = ""

--- a/Sources/Gemma4CLI/MtpSmokeCommand.swift
+++ b/Sources/Gemma4CLI/MtpSmokeCommand.swift
@@ -1,0 +1,191 @@
+// Smoke test pour valider le chargement des poids du drafter Assistant (MTP).
+//
+// Telecharge le checkpoint depuis HuggingFace, decode le config.json, instancie
+// Gemma4AssistantDraftModel, sanitize les poids et fait un update(parameters:verify:[.all])
+// qui echoue si une cle est manquante, surplus ou de mauvaise shape.
+//
+// Usage:
+//   gemma4-cli mtp-smoke                                     # default: google/gemma-4-E2B-it-assistant
+//   gemma4-cli mtp-smoke --repo google/gemma-4-E4B-it-assistant
+//   gemma4-cli mtp-smoke --no-forward                        # skip le forward synthetique
+
+import ArgumentParser
+import Foundation
+import MLX
+import MLXNN
+import Gemma4Swift
+
+struct MtpSmoke: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mtp-smoke",
+        abstract: "Valide le chargement des poids du drafter Assistant (Gemma 4 MTP)"
+    )
+
+    @Option(name: .long, help: "Repo HuggingFace du drafter Assistant")
+    var repo: String = "google/gemma-4-E2B-it-assistant"
+
+    @Option(name: .long, help: "Token HuggingFace (pour modeles prives)")
+    var hfToken: String?
+
+    @Flag(name: .long, help: "Skip le forward synthetique apres chargement")
+    var noForward: Bool = false
+
+    @Flag(name: .long, help: "Forcer le re-telechargement")
+    var force: Bool = false
+
+    func run() async throws {
+        print("[mtp-smoke] target: \(repo)")
+        print("[mtp-smoke] step 1/4: download")
+
+        let modelDir = try await Gemma4ModelDownloader.download(
+            modelId: repo,
+            token: resolveHFToken(hfToken),
+            force: force
+        ) { progress in
+            print("\r  \(Int(progress.fraction * 100))% — \(progress.currentFile)              ", terminator: "")
+            fflush(stdout)
+        }
+        print()
+        print("  -> \(modelDir.path)")
+
+        // Step 2: decode config
+        print("[mtp-smoke] step 2/4: decode config.json")
+        let configURL = modelDir.appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            print("  ERROR: config.json absent dans \(modelDir.path)")
+            throw ExitCode.failure
+        }
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: configData)
+        print("  model_type=\(config.modelType)")
+        print("  num_layers=\(config.textConfig.numHiddenLayers), hidden=\(config.textConfig.hiddenSize)")
+        print("  vocab=\(config.textConfig.vocabSize), backbone=\(config.backboneHiddenSize)")
+        print("  num_centroids=\(config.numCentroids), top_k=\(config.centroidIntermediateTopK)")
+        print("  use_ordered_embeddings=\(config.useOrderedEmbeddings), tie_word_embeddings=\(config.tieWordEmbeddings)")
+
+        // Step 3: load + sanitize weights
+        print("[mtp-smoke] step 3/4: load + sanitize safetensors")
+        let safetensorsURLs = try findSafetensors(in: modelDir)
+        guard !safetensorsURLs.isEmpty else {
+            print("  ERROR: aucun fichier .safetensors dans \(modelDir.path)")
+            throw ExitCode.failure
+        }
+        print("  found \(safetensorsURLs.count) safetensors file(s)")
+
+        var rawWeights: [String: MLXArray] = [:]
+        for url in safetensorsURLs {
+            let arrays = try MLX.loadArrays(url: url)
+            for (k, v) in arrays {
+                rawWeights[k] = v
+            }
+        }
+        print("  loaded \(rawWeights.count) raw tensors")
+
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: rawWeights,
+            tieWordEmbeddings: config.tieWordEmbeddings
+        )
+        print("  sanitized to \(sanitized.count) tensors")
+
+        // Step 4: instantiate + update(verify: .all)
+        print("[mtp-smoke] step 4/4: instantiate + update(verify: .all)")
+        let drafter = Gemma4AssistantDraftModel(config)
+
+        // Liste les parametres du module avant update — pour diagnostic en cas d'echec
+        let modelParams = drafter.parameters().flattened()
+        let modelKeys = Set(modelParams.map { $0.0 })
+        let weightKeys = Set(sanitized.keys)
+
+        let missingFromWeights = modelKeys.subtracting(weightKeys)
+        let extraInWeights = weightKeys.subtracting(modelKeys)
+
+        if !missingFromWeights.isEmpty {
+            print("  WARNING: \(missingFromWeights.count) parametres du module sans cle correspondante dans les poids:")
+            for k in missingFromWeights.sorted().prefix(20) {
+                print("    - \(k)")
+            }
+            if missingFromWeights.count > 20 {
+                print("    ... et \(missingFromWeights.count - 20) de plus")
+            }
+        }
+        if !extraInWeights.isEmpty {
+            print("  WARNING: \(extraInWeights.count) cles dans les poids sans parametre correspondant dans le module:")
+            for k in extraInWeights.sorted().prefix(20) {
+                print("    - \(k)")
+            }
+            if extraInWeights.count > 20 {
+                print("    ... et \(extraInWeights.count - 20) de plus")
+            }
+        }
+
+        let parameters = ModuleParameters.unflattened(sanitized)
+        do {
+            try drafter.update(parameters: parameters, verify: .all)
+            print("  OK: update(verify: .all) sans erreur")
+        } catch {
+            print("  ERROR update: \(error)")
+            throw ExitCode.failure
+        }
+
+        if !noForward {
+            print("[mtp-smoke] bonus: forward synthetique pour verifier les shapes a posteriori")
+            try synteticForward(drafter: drafter, config: config)
+        }
+
+        print("\n[mtp-smoke] SUCCES — \(repo) charge proprement.")
+    }
+
+    private func findSafetensors(in dir: URL) throws -> [URL] {
+        let contents = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        return contents
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private func synteticForward(drafter: Gemma4AssistantDraftModel, config: Gemma4AssistantConfig) throws {
+        let B = 1
+        let L = 1
+        let kvLen = 8
+        let numKVHeads = config.textConfig.numKeyValueHeads
+        let slidingHeadDim = config.textConfig.headDim
+        let fullHeadDim = config.textConfig.globalHeadDim
+
+        let sharedKV: SharedKVStates = [
+            "sliding_attention": (
+                keys: MLXRandom.normal([B, numKVHeads, kvLen, slidingHeadDim]),
+                values: MLXRandom.normal([B, numKVHeads, kvLen, slidingHeadDim])
+            ),
+            "full_attention": (
+                keys: MLXRandom.normal([B, numKVHeads, kvLen, fullHeadDim]),
+                values: MLXRandom.normal([B, numKVHeads, kvLen, fullHeadDim])
+            ),
+        ]
+
+        let inputs = MLXRandom.normal([B, L, 2 * config.backboneHiddenSize])
+        let (lastHidden, logits) = drafter(
+            inputsEmbeds: inputs,
+            sharedKVStates: sharedKV,
+            position: kvLen
+        )
+        eval(lastHidden, logits)
+
+        let expectedHidden = [B, L, config.backboneHiddenSize]
+        let expectedLogits = [B, L, config.textConfig.vocabSize]
+        guard lastHidden.shape == expectedHidden, logits.shape == expectedLogits else {
+            print("  shape mismatch: lastHidden=\(lastHidden.shape) (expected \(expectedHidden)), logits=\(logits.shape) (expected \(expectedLogits))")
+            throw ExitCode.failure
+        }
+
+        let hasNaN = isNaN(logits).any().item(Bool.self) || isNaN(lastHidden).any().item(Bool.self)
+        guard !hasNaN else {
+            print("  ERROR: NaN dans logits ou lastHidden")
+            throw ExitCode.failure
+        }
+
+        // Top-1 token sur les logits — juste pour avoir un signe de vie
+        let top1 = argMax(logits, axis: -1).reshaped(-1).item(Int32.self)
+        print("  shapes OK, no NaN, top1 token (sur input random) = \(top1)")
+    }
+}
+
+import MLXRandom

--- a/Sources/Gemma4CLI/MtpTrainCommand.swift
+++ b/Sources/Gemma4CLI/MtpTrainCommand.swift
@@ -1,0 +1,174 @@
+// Fine-tune le drafter MTP par auto-distillation contre un target frozen.
+//
+// Usage:
+//   gemma4-cli mtp-train \
+//     --target /path/to/target \
+//     --drafter google/gemma-4-E2B-it-assistant \
+//     --data dataset.jsonl \
+//     --iterations 200 \
+//     --output drafter_finetuned/
+
+import ArgumentParser
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXOptimizers
+import Gemma4Swift
+
+struct MtpTrain: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mtp-train",
+        abstract: "Fine-tune le drafter MTP par auto-distillation contre le target"
+    )
+
+    @Option(name: .long, help: "Chemin local vers le target")
+    var target: String
+
+    @Option(name: .long, help: "Repo HF du drafter de depart (Google Assistant)")
+    var drafter: String = "google/gemma-4-E2B-it-assistant"
+
+    @Option(name: .long, help: "Token HuggingFace")
+    var hfToken: String?
+
+    @Option(name: .long, help: "Fichier JSONL avec un champ 'text' par ligne")
+    var data: String
+
+    @Option(name: .long, help: "Repertoire de sortie pour les poids fine-tunes")
+    var output: String
+
+    @Option(name: .long, help: "Nombre d'iterations de training")
+    var iterations: Int = 100
+
+    @Option(name: .long, help: "Sequence length par chunk")
+    var seqLen: Int = 256
+
+    @Option(name: .long, help: "Learning rate")
+    var lr: Float = 1e-4
+
+    @Option(name: .long, help: "Steps entre les rapports")
+    var stepsPerReport: Int = 10
+
+    @Option(name: .long, help: "Steps entre les checkpoints")
+    var saveEvery: Int = 50
+
+    func run() async throws {
+        print("[mtp-train] target=\(target)")
+        print("[mtp-train] drafter=\(drafter)")
+        print("[mtp-train] data=\(data)")
+        print("[mtp-train] output=\(output)")
+        print("[mtp-train] iterations=\(iterations) seq_len=\(seqLen) lr=\(lr)")
+        print()
+
+        // 1. Load target (text-only)
+        print("[1/4] Load target...")
+        await Gemma4Registration.register(multimodal: false)
+        let targetURL = URL(fileURLWithPath: target)
+        let container = try await loadModelContainer(from: targetURL, using: Gemma4TokenizerLoader())
+
+        // 2. Load drafter (depuis HF + sanitize + verify)
+        print("[2/4] Load drafter...")
+        let drafterModel = try await loadDrafter(repo: drafter, hfToken: hfToken)
+
+        // 3. Charger + tokenizer le dataset
+        print("[3/4] Tokenize dataset...")
+        let dataURL = URL(fileURLWithPath: data)
+        let lines = try String(contentsOf: dataURL, encoding: .utf8)
+            .split(separator: "\n")
+            .map { String($0) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else {
+            print("Erreur: dataset vide")
+            throw ExitCode.failure
+        }
+        print("  \(lines.count) lignes")
+
+        // Setup output dir
+        let outputURL = URL(fileURLWithPath: output)
+        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+        let weightsURL = outputURL.appendingPathComponent("drafter.safetensors")
+
+        // 4. Training loop
+        print("[4/4] Training...")
+        let it = iterations
+        let sl = seqLen
+        let lrate = lr
+        let spr = stepsPerReport
+        let sve = saveEvery
+        let wURL = weightsURL
+        nonisolated(unsafe) let drafterRef = drafterModel
+        nonisolated(unsafe) let textLines = lines
+
+        try await container.perform { context in
+            guard let llm = context.model as? Gemma4LLMModel else {
+                fatalError("Expected Gemma4LLMModel for training")
+            }
+            let langModel = llm.languageModel
+            let textCfg = langModel.config
+
+            // Indices des dernieres couches concretes par type
+            let layerTypes = textCfg.resolvedLayerTypes
+            let concreteTypes = Array(layerTypes.prefix(textCfg.firstKvSharedLayerIdx))
+            guard let lastFullIdx = concreteTypes.lastIndex(of: "full_attention"),
+                  let lastSlidingIdx = concreteTypes.lastIndex(of: "sliding_attention") else {
+                fatalError("Cannot find concrete full_attention and sliding_attention layers")
+            }
+
+            // Bind drafter au target (pour input_embed dans le path d'inference)
+            drafterRef.bind(target: langModel)
+
+            // Tokeniser chaque ligne (avec chat template? non, brut pour training general)
+            print("  tokenizing \(textLines.count) lines...")
+            var tokenizedSamples: [[Int]] = []
+            for line in textLines {
+                let parsed = try parseJsonlLine(line)
+                let tokens = try context.tokenizer.encode(text: parsed)
+                if tokens.count >= sl {
+                    tokenizedSamples.append(tokens)
+                }
+            }
+            print("  \(tokenizedSamples.count) samples avec >= \(sl) tokens")
+
+            guard !tokenizedSamples.isEmpty else {
+                fatalError("Aucun sample n'a au moins \(sl) tokens")
+            }
+
+            // Optimizer Adam
+            let optimizer = Adam(learningRate: lrate)
+
+            var config = Gemma4DrafterTraining.TrainConfig()
+            config.iterations = it
+            config.seqLen = sl
+            config.batchSize = 1
+            config.stepsPerReport = spr
+            config.saveEvery = sve
+            config.weightsURL = wURL
+
+            try Gemma4DrafterTraining.trainDrafter(
+                drafter: drafterRef,
+                target: langModel,
+                tokenizedSamples: tokenizedSamples,
+                lastFullCacheIdx: lastFullIdx,
+                lastSlidingCacheIdx: lastSlidingIdx,
+                optimizer: optimizer,
+                config: config
+            )
+        }
+
+        print("\n[mtp-train] DONE — drafter sauve dans \(weightsURL.path)")
+    }
+
+    /// Parse une ligne JSONL avec un champ "text"
+    private func parseJsonlLine(_ line: String) throws -> String {
+        guard let data = line.data(using: .utf8) else {
+            throw NSError(domain: "MtpTrain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid line"])
+        }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let text = json["text"] as? String else {
+            throw NSError(domain: "MtpTrain", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Line missing 'text' field: \(line.prefix(80))"
+            ])
+        }
+        return text
+    }
+}

--- a/Sources/Gemma4CLI/MtpTrainCommand.swift
+++ b/Sources/Gemma4CLI/MtpTrainCommand.swift
@@ -43,6 +43,9 @@ struct MtpTrain: AsyncParsableCommand {
     @Option(name: .long, help: "Sequence length par chunk")
     var seqLen: Int = 256
 
+    @Option(name: .long, help: "Batch size (chunks per step)")
+    var batchSize: Int = 1
+
     @Option(name: .long, help: "Learning rate")
     var lr: Float = 1e-4
 
@@ -92,6 +95,7 @@ struct MtpTrain: AsyncParsableCommand {
         print("[4/4] Training...")
         let it = iterations
         let sl = seqLen
+        let bs = batchSize
         let lrate = lr
         let spr = stepsPerReport
         let sve = saveEvery
@@ -139,7 +143,7 @@ struct MtpTrain: AsyncParsableCommand {
             var config = Gemma4DrafterTraining.TrainConfig()
             config.iterations = it
             config.seqLen = sl
-            config.batchSize = 1
+            config.batchSize = bs
             config.stepsPerReport = spr
             config.saveEvery = sve
             config.weightsURL = wURL

--- a/Sources/Gemma4CLI/MtpTrainCommand.swift
+++ b/Sources/Gemma4CLI/MtpTrainCommand.swift
@@ -31,8 +31,17 @@ struct MtpTrain: AsyncParsableCommand {
     @Option(name: .long, help: "Token HuggingFace")
     var hfToken: String?
 
-    @Option(name: .long, help: "Fichier JSONL avec un champ 'text' par ligne")
+    @Option(name: .long, help: "Fichier JSONL avec un champ 'text' par ligne (ou 'messages' pour chat)")
     var data: String
+
+    @Option(name: .long, help: "Optionnel: fichier JSONL de validation. Si fourni, eval loss tous les --steps-per-valid")
+    var validData: String?
+
+    @Option(name: .long, help: "Frequence de validation (en iterations). 0 = pas de valid (default)")
+    var stepsPerValid: Int = 0
+
+    @Option(name: .long, help: "Nombre de batches a evaluer sur la valid")
+    var validBatches: Int = 8
 
     @Option(name: .long, help: "Repertoire de sortie pour les poids fine-tunes")
     var output: String
@@ -73,7 +82,7 @@ struct MtpTrain: AsyncParsableCommand {
         print("[2/4] Load drafter...")
         let drafterModel = try await loadDrafter(repo: drafter, hfToken: hfToken)
 
-        // 3. Charger + tokenizer le dataset
+        // 3. Charger + tokenizer le dataset (train + optionnel valid)
         print("[3/4] Tokenize dataset...")
         let dataURL = URL(fileURLWithPath: data)
         let lines = try String(contentsOf: dataURL, encoding: .utf8)
@@ -84,7 +93,17 @@ struct MtpTrain: AsyncParsableCommand {
             print("Erreur: dataset vide")
             throw ExitCode.failure
         }
-        print("  \(lines.count) lignes")
+        print("  train: \(lines.count) lignes")
+
+        var validLines: [String] = []
+        if let vd = validData {
+            let validURL = URL(fileURLWithPath: vd)
+            validLines = try String(contentsOf: validURL, encoding: .utf8)
+                .split(separator: "\n")
+                .map { String($0) }
+                .filter { !$0.isEmpty }
+            print("  valid: \(validLines.count) lignes")
+        }
 
         // Setup output dir
         let outputURL = URL(fileURLWithPath: output)
@@ -98,8 +117,11 @@ struct MtpTrain: AsyncParsableCommand {
         let bs = batchSize
         let lrate = lr
         let spr = stepsPerReport
+        let spv = stepsPerValid
+        let vb = validBatches
         let sve = saveEvery
         let wURL = weightsURL
+        nonisolated(unsafe) let validLinesRef = validLines
         nonisolated(unsafe) let drafterRef = drafterModel
         nonisolated(unsafe) let textLines = lines
 
@@ -155,10 +177,29 @@ struct MtpTrain: AsyncParsableCommand {
                     }
                 }
             }
-            print("  \(tokenizedSamples.count) samples (chunks de \(sl)), \(failedLines) lignes echouees")
+            print("  train: \(tokenizedSamples.count) samples (chunks de \(sl)), \(failedLines) lignes echouees")
 
             guard !tokenizedSamples.isEmpty else {
                 fatalError("Aucun sample n'a au moins \(sl) tokens")
+            }
+
+            // Tokeniser la valid (si fournie)
+            var validSamples: [[Int]] = []
+            var validBuffer: [Int] = []
+            for line in validLinesRef {
+                guard let toks = try? parseAndTokenizeJsonlLine(line, tokenizer: context.tokenizer) else { continue }
+                if toks.count >= sl {
+                    validSamples.append(toks)
+                } else {
+                    validBuffer.append(contentsOf: toks)
+                    while validBuffer.count >= sl {
+                        validSamples.append(Array(validBuffer.prefix(sl)))
+                        validBuffer.removeFirst(sl)
+                    }
+                }
+            }
+            if !validSamples.isEmpty {
+                print("  valid: \(validSamples.count) samples")
             }
 
             // Optimizer Adam
@@ -169,6 +210,8 @@ struct MtpTrain: AsyncParsableCommand {
             config.seqLen = sl
             config.batchSize = bs
             config.stepsPerReport = spr
+            config.stepsPerValid = spv
+            config.validBatches = vb
             config.saveEvery = sve
             config.weightsURL = wURL
 
@@ -176,6 +219,7 @@ struct MtpTrain: AsyncParsableCommand {
                 drafter: drafterRef,
                 target: langModel,
                 tokenizedSamples: tokenizedSamples,
+                validSamples: validSamples,
                 lastFullCacheIdx: lastFullIdx,
                 lastSlidingCacheIdx: lastSlidingIdx,
                 optimizer: optimizer,

--- a/Sources/Gemma4CLI/MtpTrainCommand.swift
+++ b/Sources/Gemma4CLI/MtpTrainCommand.swift
@@ -121,17 +121,41 @@ struct MtpTrain: AsyncParsableCommand {
             // Bind drafter au target (pour input_embed dans le path d'inference)
             drafterRef.bind(target: langModel)
 
-            // Tokeniser chaque ligne (avec chat template? non, brut pour training general)
+            // Tokeniser chaque ligne. Supporte 2 formats JSONL:
+            //  - {"text": "..."} : texte brut (concatene les chunks de seqLen)
+            //  - {"messages": [{"role": ..., "content": ...}, ...]} : chat,
+            //    rendu via applyChatTemplate, regroupe pour atteindre seqLen
             print("  tokenizing \(textLines.count) lines...")
+            var allTokens: [Int] = []
             var tokenizedSamples: [[Int]] = []
-            for line in textLines {
-                let parsed = try parseJsonlLine(line)
-                let tokens = try context.tokenizer.encode(text: parsed)
+            var failedLines = 0
+            for (lineIdx, line) in textLines.enumerated() {
+                let tokens: [Int]
+                do {
+                    tokens = try parseAndTokenizeJsonlLine(line, tokenizer: context.tokenizer)
+                } catch {
+                    failedLines += 1
+                    if failedLines <= 3 {
+                        print("  line \(lineIdx + 1) failed: \(error.localizedDescription)")
+                        print("  preview: \(line.prefix(120))")
+                    }
+                    continue
+                }
+                if tokens.isEmpty { continue }
+
+                // Si la ligne fait deja >= seqLen, en faire un sample.
                 if tokens.count >= sl {
                     tokenizedSamples.append(tokens)
+                } else {
+                    // Sinon accumuler dans un buffer global, decouper en chunks de seqLen
+                    allTokens.append(contentsOf: tokens)
+                    while allTokens.count >= sl {
+                        tokenizedSamples.append(Array(allTokens.prefix(sl)))
+                        allTokens.removeFirst(sl)
+                    }
                 }
             }
-            print("  \(tokenizedSamples.count) samples avec >= \(sl) tokens")
+            print("  \(tokenizedSamples.count) samples (chunks de \(sl)), \(failedLines) lignes echouees")
 
             guard !tokenizedSamples.isEmpty else {
                 fatalError("Aucun sample n'a au moins \(sl) tokens")
@@ -162,17 +186,33 @@ struct MtpTrain: AsyncParsableCommand {
         print("\n[mtp-train] DONE — drafter sauve dans \(weightsURL.path)")
     }
 
-    /// Parse une ligne JSONL avec un champ "text"
-    private func parseJsonlLine(_ line: String) throws -> String {
+    /// Parse une ligne JSONL et la tokenize. Supporte:
+    ///  - {"text": "..."} : tokenise via encode()
+    ///  - {"messages": [...]} : tokenise via applyChatTemplate
+    private func parseAndTokenizeJsonlLine(_ line: String, tokenizer: any Tokenizer) throws -> [Int] {
         guard let data = line.data(using: .utf8) else {
             throw NSError(domain: "MtpTrain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid line"])
         }
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let text = json["text"] as? String else {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw NSError(domain: "MtpTrain", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "Line missing 'text' field: \(line.prefix(80))"
+                NSLocalizedDescriptionKey: "Not valid JSON: \(line.prefix(80))"
             ])
         }
-        return text
+
+        if let text = json["text"] as? String {
+            return try tokenizer.encode(text: text)
+        }
+        if let messages = json["messages"] as? [[String: Any]] {
+            // Convertir au format [String: String] requis par applyChatTemplate
+            let strMessages: [[String: String]] = messages.compactMap { m in
+                guard let role = m["role"] as? String,
+                      let content = m["content"] as? String else { return nil }
+                return ["role": role, "content": content]
+            }
+            return try tokenizer.applyChatTemplate(messages: strMessages)
+        }
+        throw NSError(domain: "MtpTrain", code: 3, userInfo: [
+            NSLocalizedDescriptionKey: "Line missing 'text' or 'messages': \(line.prefix(80))"
+        ])
     }
 }

--- a/Sources/Gemma4Swift/Configuration/Gemma4AssistantConfig.swift
+++ b/Sources/Gemma4Swift/Configuration/Gemma4AssistantConfig.swift
@@ -1,0 +1,75 @@
+// Configuration du modele drafter Gemma 4 Assistant (MTP)
+//
+// Le modele Assistant est un drafter de speculative decoding qui se branche sur
+// un modele cible (gemma-4-e2b-it / gemma-4-e4b-it). Il consomme les hidden
+// states du target via pre_projection (2*backbone -> hidden) et reprojette ses
+// sorties vers l'espace du target via post_projection (hidden -> backbone).
+//
+// Reference: google/gemma-4-E2B-it-assistant config.json
+// Implementation Python de reference: mlx-vlm/speculative/drafters/gemma4_assistant
+
+import Foundation
+
+/// Configuration du modele drafter Gemma 4 Assistant
+public struct Gemma4AssistantConfig: Codable {
+    public let modelType: String
+    public let textConfig: Gemma4TextConfig
+
+    /// Hidden size du modele cible (backbone). Le drafter projette
+    /// concat(target_embed, target_hidden) [2 * backboneHiddenSize] -> textConfig.hiddenSize.
+    public let backboneHiddenSize: Int
+
+    /// Nombre de centroides pour le MaskedEmbedder (sparse softmax sur le vocab).
+    public let numCentroids: Int
+
+    /// Top-K centroides selectionnes pour le calcul de logits sparse.
+    public let centroidIntermediateTopK: Int
+
+    /// Si true, utiliser le MaskedEmbedder a centroides plutot que tied/lm_head pour les logits.
+    public let useOrderedEmbeddings: Bool
+
+    /// Word embeddings partages entre l'embedding et la projection de sortie (top-level).
+    public let tieWordEmbeddings: Bool
+
+    /// Tokens speciaux multimodaux (passes par le target, pas utilises par le drafter
+    /// directement, mais conserves pour symetrie avec Gemma4Config).
+    public let imageTokenId: Int
+    public let audioTokenId: Int
+    public let boiTokenId: Int
+    public let eoiTokenId: Int
+    public let boaTokenId: Int
+    public let eoaTokenId: Int
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case textConfig = "text_config"
+        case backboneHiddenSize = "backbone_hidden_size"
+        case numCentroids = "num_centroids"
+        case centroidIntermediateTopK = "centroid_intermediate_top_k"
+        case useOrderedEmbeddings = "use_ordered_embeddings"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case imageTokenId = "image_token_id"
+        case audioTokenId = "audio_token_id"
+        case boiTokenId = "boi_token_id"
+        case eoiTokenId = "eoi_token_id"
+        case boaTokenId = "boa_token_id"
+        case eoaTokenId = "eoa_token_id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decode(String.self, forKey: .modelType)
+        textConfig = try c.decode(Gemma4TextConfig.self, forKey: .textConfig)
+        backboneHiddenSize = try c.decode(Int.self, forKey: .backboneHiddenSize)
+        numCentroids = try c.decodeIfPresent(Int.self, forKey: .numCentroids) ?? 0
+        centroidIntermediateTopK = try c.decodeIfPresent(Int.self, forKey: .centroidIntermediateTopK) ?? 0
+        useOrderedEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .useOrderedEmbeddings) ?? false
+        tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+        imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
+        audioTokenId = try c.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
+        boiTokenId = try c.decodeIfPresent(Int.self, forKey: .boiTokenId) ?? 255999
+        eoiTokenId = try c.decodeIfPresent(Int.self, forKey: .eoiTokenId) ?? 258882
+        boaTokenId = try c.decodeIfPresent(Int.self, forKey: .boaTokenId) ?? 256000
+        eoaTokenId = try c.decodeIfPresent(Int.self, forKey: .eoaTokenId) ?? 258883
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4AssistantWeightSanitizer.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4AssistantWeightSanitizer.swift
@@ -1,0 +1,52 @@
+// Sanitizer dedie aux poids du modele Assistant (drafter MTP)
+//
+// Structure des poids dans le checkpoint Google:
+//   model.embed_tokens.weight
+//   model.layers.{0..3}.{self_attn,mlp,...}.weight
+//   model.norm.weight
+//   pre_projection.weight
+//   post_projection.weight
+//   masked_embedding.centroids.weight
+//   masked_embedding.token_ordering              (buffer, doit etre Int32)
+//   lm_head.weight                               (optionnel, skip si tie_word_embeddings)
+//
+// La structure Swift de Gemma4AssistantDraftModel est concue pour matcher 1:1
+// ces cles, donc aucun renaming n'est necessaire.
+
+import Foundation
+import MLX
+
+public enum Gemma4AssistantWeightSanitizer {
+
+    /// Nettoie les poids charges depuis le checkpoint du drafter Assistant.
+    /// - Parameters:
+    ///   - weights: dictionnaire brut des poids (cles au format PyTorch).
+    ///   - tieWordEmbeddings: si true, skip `lm_head.weight` (les embeddings sont reutilisees).
+    public static func sanitize(
+        weights: [String: MLXArray],
+        tieWordEmbeddings: Bool
+    ) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+
+        for (key, value) in weights {
+            // Skip rotary embeddings pre-calculees (defensif: pas attendues dans les checkpoints
+            // mais on s'aligne sur le sanitizer principal)
+            if key.contains("rotary_emb") { continue }
+            if key.contains(".rope.") && key.hasSuffix(".freqs") { continue }
+
+            // Skip lm_head si word embeddings tied (le MaskedEmbedder ou les embeddings
+            // partagees produisent les logits)
+            if tieWordEmbeddings && key == "lm_head.weight" { continue }
+
+            // Convertir le buffer token_ordering en Int32 — c'est un index, pas un float
+            if key == "masked_embedding.token_ordering" {
+                out[key] = value.asType(.int32)
+                continue
+            }
+
+            out[key] = value
+        }
+
+        return out
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
@@ -90,10 +90,25 @@ public actor Gemma4MTPPipeline {
         let seqVerify = sequentialVerify
 
         let stats = try await target.perform { context -> Stats in
-            guard let llm = context.model as? Gemma4LLMModel else {
+            // Adapter: supporte Gemma4LLMModel (text-only) ET Gemma4MultimodalLLMModel
+            // (image/video/audio via les pendingX deja set sur le model par le caller).
+            let langModel: Gemma4LanguageModel
+            let modelForward: (MLXArray, [any KVCache]) -> LanguageForwardOutput
+            if let textOnly = context.model as? Gemma4LLMModel {
+                langModel = textOnly.languageModel
+                modelForward = { inputs, c in
+                    textOnly.languageModel.forwardWithIntermediates(
+                        inputs: inputs, cache: c.map { $0 as KVCache? }
+                    )
+                }
+            } else if let multimodal = context.model as? Gemma4MultimodalLLMModel {
+                langModel = multimodal.languageModel
+                modelForward = { inputs, c in
+                    multimodal.forwardWithIntermediates(inputs, cache: c)
+                }
+            } else {
                 throw MTPError.unsupportedModel(String(describing: type(of: context.model)))
             }
-            let langModel = llm.languageModel
             let textCfg = langModel.config
 
             var s = Stats()
@@ -108,12 +123,9 @@ public actor Gemma4MTPPipeline {
             }
             let inputArr = MLXArray(promptIds.map { Int32($0) }).reshaped(1, -1)
 
-            // 2) Cache + prefill
+            // 2) Cache + prefill (multimodal: pendingX deja set sur le model par caller)
             let cache = langModel.makeCache()
-            let cacheArr = cache.map { $0 as KVCache? }
-            let prefillOut = langModel.forwardWithIntermediates(
-                inputs: inputArr, cache: cacheArr
-            )
+            let prefillOut = modelForward(inputArr, cache)
             eval(prefillOut.logits, prefillOut.preNormHiddenStates)
 
             let promptLen = inputArr.dim(1)
@@ -185,9 +197,7 @@ public actor Gemma4MTPPipeline {
                     var allPreNormHidden: [MLXArray] = []
                     for i in 0 ..< bs {
                         let single = verifyInput[0..., i..<(i+1)]
-                        let stepOut = langModel.forwardWithIntermediates(
-                            inputs: single, cache: cacheArr
-                        )
+                        let stepOut = modelForward(single, cache)
                         eval(stepOut.logits, stepOut.preNormHiddenStates)
                         allLogits.append(stepOut.logits)
                         allPreNormHidden.append(stepOut.preNormHiddenStates)
@@ -201,9 +211,7 @@ public actor Gemma4MTPPipeline {
                         intermediates: []  // unused
                     )
                 } else {
-                    verifyOut = langModel.forwardWithIntermediates(
-                        inputs: verifyInput, cache: cacheArr
-                    )
+                    verifyOut = modelForward(verifyInput, cache)
                     eval(verifyOut.logits, verifyOut.preNormHiddenStates)
                 }
 

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
@@ -44,9 +44,38 @@ public actor Gemma4MTPPipeline {
                 do {
                     try await self.runLoop(
                         prompt: prompt,
+                        preTokenizedIds: nil,
                         blockSize: blockSize,
                         maxTokens: maxTokens,
                         useChatTemplate: useChatTemplate,
+                        sequentialVerify: sequentialVerify,
+                        continuation: continuation
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Variante qui prend des tokens deja pre-tokenises (utile pour multi-turn chat
+    /// ou le caller doit appliquer le chat template sur l'historique complet).
+    public func mtpStreamFromTokens(
+        tokenIds: [Int],
+        blockSize: Int = 4,
+        maxTokens: Int = 256,
+        sequentialVerify: Bool = false
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    try await self.runLoop(
+                        prompt: "",
+                        preTokenizedIds: tokenIds,
+                        blockSize: blockSize,
+                        maxTokens: maxTokens,
+                        useChatTemplate: false,
                         sequentialVerify: sequentialVerify,
                         continuation: continuation
                     )
@@ -74,6 +103,7 @@ public actor Gemma4MTPPipeline {
 
     private func runLoop(
         prompt: String,
+        preTokenizedIds: [Int]?,
         blockSize: Int,
         maxTokens: Int,
         useChatTemplate: Bool,
@@ -88,6 +118,7 @@ public actor Gemma4MTPPipeline {
         let useTpl = useChatTemplate
         let userPrompt = prompt
         let seqVerify = sequentialVerify
+        let preTokens = preTokenizedIds
 
         let stats = try await target.perform { context -> Stats in
             // Adapter: supporte Gemma4LLMModel (text-only) ET Gemma4MultimodalLLMModel
@@ -113,9 +144,11 @@ public actor Gemma4MTPPipeline {
 
             var s = Stats()
 
-            // 1) Tokenize
+            // 1) Tokenize (sauf si deja pre-tokenise par le caller, e.g. chat multi-turn)
             let promptIds: [Int]
-            if useTpl {
+            if let pre = preTokens {
+                promptIds = pre
+            } else if useTpl {
                 let messages: [[String: String]] = [["role": "user", "content": userPrompt]]
                 promptIds = try context.tokenizer.applyChatTemplate(messages: messages)
             } else {

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
@@ -29,11 +29,15 @@ public actor Gemma4MTPPipeline {
     }
 
     /// Genere une reponse en streaming MTP, equivalent a `ChatSession.streamResponse(to:)`.
+    /// - Parameter sequentialVerify: si true, le verify est fait token-par-token au lieu
+    ///   de en parallele. DIAGNOSTIC ONLY — perf catastrophique mais permet de tester si
+    ///   la precision BF16 du parallel forward est la cause d'un faible taux d'acceptation.
     public func mtpStream(
         prompt: String,
         blockSize: Int = 4,
         maxTokens: Int = 256,
-        useChatTemplate: Bool = true
+        useChatTemplate: Bool = true,
+        sequentialVerify: Bool = false
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             Task {
@@ -43,6 +47,7 @@ public actor Gemma4MTPPipeline {
                         blockSize: blockSize,
                         maxTokens: maxTokens,
                         useChatTemplate: useChatTemplate,
+                        sequentialVerify: sequentialVerify,
                         continuation: continuation
                     )
                     continuation.finish()
@@ -72,6 +77,7 @@ public actor Gemma4MTPPipeline {
         blockSize: Int,
         maxTokens: Int,
         useChatTemplate: Bool,
+        sequentialVerify: Bool,
         continuation: AsyncThrowingStream<String, Error>.Continuation
     ) async throws {
         precondition(blockSize >= 2, "blockSize doit etre >= 2 pour faire de la speculation")
@@ -81,6 +87,7 @@ public actor Gemma4MTPPipeline {
         let maxTok = maxTokens
         let useTpl = useChatTemplate
         let userPrompt = prompt
+        let seqVerify = sequentialVerify
 
         let stats = try await target.perform { context -> Stats in
             guard let llm = context.model as? Gemma4LLMModel else {
@@ -170,10 +177,35 @@ public actor Gemma4MTPPipeline {
                     .asType(.int32)
                     .reshaped(1, bs)
 
-                let verifyOut = langModel.forwardWithIntermediates(
-                    inputs: verifyInput, cache: cacheArr
-                )
-                eval(verifyOut.logits, verifyOut.preNormHiddenStates)
+                let verifyOut: LanguageForwardOutput
+                if seqVerify {
+                    // Sequential verify: bs forwards de L=1 chacun. Plus lent mais
+                    // numeriquement bit-exact equivalent au sequential decode.
+                    var allLogits: [MLXArray] = []
+                    var allPreNormHidden: [MLXArray] = []
+                    for i in 0 ..< bs {
+                        let single = verifyInput[0..., i..<(i+1)]
+                        let stepOut = langModel.forwardWithIntermediates(
+                            inputs: single, cache: cacheArr
+                        )
+                        eval(stepOut.logits, stepOut.preNormHiddenStates)
+                        allLogits.append(stepOut.logits)
+                        allPreNormHidden.append(stepOut.preNormHiddenStates)
+                    }
+                    let logits = concatenated(allLogits, axis: 1)
+                    let preNorm = concatenated(allPreNormHidden, axis: 1)
+                    verifyOut = LanguageForwardOutput(
+                        logits: logits,
+                        hiddenStates: preNorm,  // unused
+                        preNormHiddenStates: preNorm,
+                        intermediates: []  // unused
+                    )
+                } else {
+                    verifyOut = langModel.forwardWithIntermediates(
+                        inputs: verifyInput, cache: cacheArr
+                    )
+                    eval(verifyOut.logits, verifyOut.preNormHiddenStates)
+                }
 
                 // Sample target sur chaque position [B, bs, vocab] -> [B, bs]
                 let targetTokensArr = argMax(verifyOut.logits, axis: -1).reshaped(-1)

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
@@ -190,7 +190,7 @@ public actor Gemma4MTPPipeline {
 
             // 6) Boucle MTP
             while s.emittedTokens < maxTok {
-                // Sharedeading des K/V depuis le cache (etat valide jusqu'a cache.offset)
+                // Lecture des K/V partages depuis le cache (etat valide jusqu'a cache.offset)
                 let kvOffset = cache[lastFullCacheIdx].offset
                 let sharedKV = extractSharedKV(
                     cache: cache,
@@ -299,10 +299,6 @@ public actor Gemma4MTPPipeline {
             return s
         }
 
-        await MainActor.run { [stats] in
-            // Side-effect: mettre a jour les stats accessibles
-            // Note: lastStats est isolated par l'actor, donc setter via une methode async
-        }
         await self.setStats(stats)
     }
 

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
@@ -107,13 +107,13 @@ public actor Gemma4MTPPipeline {
             let prefillOut = langModel.forwardWithIntermediates(
                 inputs: inputArr, cache: cacheArr
             )
-            eval(prefillOut.logits, prefillOut.hiddenStates)
+            eval(prefillOut.logits, prefillOut.preNormHiddenStates)
 
             let promptLen = inputArr.dim(1)
 
             // 3) First bonus + last hidden
             var bonus = argMax(prefillOut.logits[0, promptLen - 1, 0...], axis: -1).item(Int32.self)
-            var lastHidden = prefillOut.hiddenStates[0..., (promptLen - 1) ..< promptLen, 0...]
+            var lastHidden = prefillOut.preNormHiddenStates[0..., (promptLen - 1) ..< promptLen, 0...]
 
             // Yield le premier token (sauf si c'est deja un EOS)
             if isEOS(bonus, tokenizer: context.tokenizer) {
@@ -173,7 +173,7 @@ public actor Gemma4MTPPipeline {
                 let verifyOut = langModel.forwardWithIntermediates(
                     inputs: verifyInput, cache: cacheArr
                 )
-                eval(verifyOut.logits, verifyOut.hiddenStates)
+                eval(verifyOut.logits, verifyOut.preNormHiddenStates)
 
                 // Sample target sur chaque position [B, bs, vocab] -> [B, bs]
                 let targetTokensArr = argMax(verifyOut.logits, axis: -1).reshaped(-1)
@@ -218,7 +218,7 @@ public actor Gemma4MTPPipeline {
                 // Update bonus + lastHidden pour le prochain round
                 bonus = walkRes.newTokens.last ?? bonus
                 let acceptedIdx = walkRes.accepted  // [0..bs-1]
-                lastHidden = verifyOut.hiddenStates[
+                lastHidden = verifyOut.preNormHiddenStates[
                     0..., acceptedIdx ..< (acceptedIdx + 1), 0...
                 ]
             }

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MTPPipeline.swift
@@ -1,0 +1,290 @@
+// Pipeline MTP (Multi-Token Prediction / Speculative Decoding) pour Gemma 4 Assistant.
+//
+// Boucle d'un round:
+//   1. setSharedKV depuis cache.state (apres prefill ou verify precedent)
+//   2. drafter.draftBlock(lastBonus, lastHidden, blockSize) -> [B, blockSize-1] drafts
+//   3. Target verify: forward sur [bonus | drafts] (blockSize tokens, en parallele)
+//   4. Walk: accepter les drafts jusqu'a la 1ere divergence + correction du target
+//   5. Yield les tokens emis
+//   6. Si drafts rejetes: trim cache pour les positions invalides
+//   7. Update bonus/hidden/sharedKV pour le round suivant
+//
+// Output: AsyncThrowingStream<String, Error> identique au contrat ChatSession.
+// Le user voit les tokens en micro-rafales de 1 a blockSize tokens.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+public actor Gemma4MTPPipeline {
+
+    public let drafter: Gemma4AssistantDraftModel
+
+    nonisolated private let target: ModelContainer
+
+    public init(target: ModelContainer, drafter: Gemma4AssistantDraftModel) {
+        self.target = target
+        self.drafter = drafter
+    }
+
+    /// Genere une reponse en streaming MTP, equivalent a `ChatSession.streamResponse(to:)`.
+    public func mtpStream(
+        prompt: String,
+        blockSize: Int = 4,
+        maxTokens: Int = 256,
+        useChatTemplate: Bool = true
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    try await self.runLoop(
+                        prompt: prompt,
+                        blockSize: blockSize,
+                        maxTokens: maxTokens,
+                        useChatTemplate: useChatTemplate,
+                        continuation: continuation
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Statistiques d'un run MTP — exposees apres la fin du stream.
+    public struct Stats: Sendable {
+        public var rounds: Int = 0
+        public var totalDrafts: Int = 0
+        public var acceptedDrafts: Int = 0
+        public var emittedTokens: Int = 0
+
+        public var acceptRate: Double {
+            totalDrafts > 0 ? Double(acceptedDrafts) / Double(totalDrafts) : 0
+        }
+    }
+
+    public private(set) var lastStats: Stats = Stats()
+
+    private func runLoop(
+        prompt: String,
+        blockSize: Int,
+        maxTokens: Int,
+        useChatTemplate: Bool,
+        continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) async throws {
+        precondition(blockSize >= 2, "blockSize doit etre >= 2 pour faire de la speculation")
+
+        nonisolated(unsafe) let drafterRef = drafter
+        let bs = blockSize
+        let maxTok = maxTokens
+        let useTpl = useChatTemplate
+        let userPrompt = prompt
+
+        let stats = try await target.perform { context -> Stats in
+            guard let llm = context.model as? Gemma4LLMModel else {
+                throw MTPError.unsupportedModel(String(describing: type(of: context.model)))
+            }
+            let langModel = llm.languageModel
+            let textCfg = langModel.config
+
+            var s = Stats()
+
+            // 1) Tokenize
+            let promptIds: [Int]
+            if useTpl {
+                let messages: [[String: String]] = [["role": "user", "content": userPrompt]]
+                promptIds = try context.tokenizer.applyChatTemplate(messages: messages)
+            } else {
+                promptIds = try context.tokenizer.encode(text: userPrompt)
+            }
+            let inputArr = MLXArray(promptIds.map { Int32($0) }).reshaped(1, -1)
+
+            // 2) Cache + prefill
+            let cache = langModel.makeCache()
+            let cacheArr = cache.map { $0 as KVCache? }
+            let prefillOut = langModel.forwardWithIntermediates(
+                inputs: inputArr, cache: cacheArr
+            )
+            eval(prefillOut.logits, prefillOut.hiddenStates)
+
+            let promptLen = inputArr.dim(1)
+
+            // 3) First bonus + last hidden
+            var bonus = argMax(prefillOut.logits[0, promptLen - 1, 0...], axis: -1).item(Int32.self)
+            var lastHidden = prefillOut.hiddenStates[0..., (promptLen - 1) ..< promptLen, 0...]
+
+            // Yield le premier token (sauf si c'est deja un EOS)
+            if isEOS(bonus, tokenizer: context.tokenizer) {
+                return s
+            }
+            try yieldToken(bonus, tokenizer: context.tokenizer, continuation: continuation)
+            s.emittedTokens = 1
+            if s.emittedTokens >= maxTok {
+                return s
+            }
+
+            // 4) Cache indices pour shared K/V (derniere couche concrete par type)
+            let layerTypes = textCfg.resolvedLayerTypes
+            let concreteTypes = Array(layerTypes.prefix(textCfg.firstKvSharedLayerIdx))
+            guard let lastFullCacheIdx = concreteTypes.lastIndex(of: "full_attention"),
+                  let lastSlidingCacheIdx = concreteTypes.lastIndex(of: "sliding_attention") else {
+                throw MTPError.cacheLayoutInvalid
+            }
+
+            // 5) Bind drafter au target
+            drafterRef.bind(target: langModel)
+
+            // 6) Boucle MTP
+            while s.emittedTokens < maxTok {
+                // Sharedeading des K/V depuis le cache (etat valide jusqu'a cache.offset)
+                let kvOffset = cache[lastFullCacheIdx].offset
+                let sharedKV = extractSharedKV(
+                    cache: cache,
+                    fullIdx: lastFullCacheIdx,
+                    slidingIdx: lastSlidingCacheIdx
+                )
+
+                drafterRef.setSharedKV(sharedKV, kvOffset: kvOffset)
+
+                // Drafter genere bs-1 tokens
+                let drafts = drafterRef.draftBlock(
+                    lastBonus: bonus,
+                    hidden: lastHidden,
+                    blockSize: bs
+                ) { logits in argMax(logits, axis: -1) }
+                eval(drafts)
+
+                // Materialiser les drafts en [Int32]
+                var draftIds: [Int32] = []
+                draftIds.reserveCapacity(drafts.dim(1))
+                for i in 0 ..< drafts.dim(1) {
+                    draftIds.append(drafts[0, i].item(Int32.self))
+                }
+
+                // Target verify: forward sur [bonus | drafts] de longueur bs
+                let bonusArr = MLXArray([bonus])
+                let draftsFlat = drafts.reshaped(-1)
+                let verifyInput = concatenated([bonusArr, draftsFlat], axis: 0)
+                    .asType(.int32)
+                    .reshaped(1, bs)
+
+                let verifyOut = langModel.forwardWithIntermediates(
+                    inputs: verifyInput, cache: cacheArr
+                )
+                eval(verifyOut.logits, verifyOut.hiddenStates)
+
+                // Sample target sur chaque position [B, bs, vocab] -> [B, bs]
+                let targetTokensArr = argMax(verifyOut.logits, axis: -1).reshaped(-1)
+                eval(targetTokensArr)
+                var targetIds: [Int32] = []
+                targetIds.reserveCapacity(bs)
+                for i in 0 ..< bs {
+                    targetIds.append(targetTokensArr[i].item(Int32.self))
+                }
+
+                // Walk
+                let budget = maxTok - s.emittedTokens
+                let walkRes = SpeculativeWalk.walk(
+                    drafts: draftIds, targets: targetIds, budget: budget
+                )
+                s.rounds += 1
+                s.totalDrafts += draftIds.count
+                s.acceptedDrafts += walkRes.accepted
+
+                // Yield les tokens emis (stop avant EOS, ne yield pas l'EOS lui-meme)
+                var sawEOS = false
+                for tok in walkRes.newTokens {
+                    if isEOS(tok, tokenizer: context.tokenizer) {
+                        sawEOS = true
+                        break
+                    }
+                    try yieldToken(tok, tokenizer: context.tokenizer, continuation: continuation)
+                    s.emittedTokens += 1
+                    if s.emittedTokens >= maxTok { break }
+                }
+                if sawEOS || s.emittedTokens >= maxTok { return s }
+
+                // Rollback du cache: les positions de drafts rejetes (apres l'index accepted)
+                // ont ete ecrites mais sont invalides. Trim de (bs - 1 - accepted).
+                // Note: walkRes.accepted = nb drafts matches; on a ecrit bs slots dans cache,
+                // garde les (accepted + 1) premiers (bonus + drafts acceptes), trim le reste.
+                let toTrim = bs - 1 - walkRes.accepted
+                if toTrim > 0 {
+                    trimPromptCache(cache, numTokens: toTrim)
+                }
+
+                // Update bonus + lastHidden pour le prochain round
+                bonus = walkRes.newTokens.last ?? bonus
+                let acceptedIdx = walkRes.accepted  // [0..bs-1]
+                lastHidden = verifyOut.hiddenStates[
+                    0..., acceptedIdx ..< (acceptedIdx + 1), 0...
+                ]
+            }
+
+            return s
+        }
+
+        await MainActor.run { [stats] in
+            // Side-effect: mettre a jour les stats accessibles
+            // Note: lastStats est isolated par l'actor, donc setter via une methode async
+        }
+        await self.setStats(stats)
+    }
+
+    private func setStats(_ s: Stats) {
+        self.lastStats = s
+    }
+
+    /// Extrait (full, sliding) K/V depuis le cache du target
+    private nonisolated func extractSharedKV(
+        cache: [any KVCache],
+        fullIdx: Int,
+        slidingIdx: Int
+    ) -> SharedKVStates {
+        let fullState = cache[fullIdx].state
+        let slidingState = cache[slidingIdx].state
+        precondition(fullState.count >= 2 && slidingState.count >= 2,
+                     "Cache state inattendu (full=\(fullState.count), sliding=\(slidingState.count))")
+        return [
+            "full_attention": (keys: fullState[0], values: fullState[1]),
+            "sliding_attention": (keys: slidingState[0], values: slidingState[1]),
+        ]
+    }
+
+    private nonisolated func yieldToken(
+        _ tokenId: Int32,
+        tokenizer: any Tokenizer,
+        continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) throws {
+        let piece = tokenizer.decode(tokenIds: [Int(tokenId)])
+        continuation.yield(piece)
+    }
+
+    private nonisolated func isEOS(_ tokenId: Int32, tokenizer: any Tokenizer) -> Bool {
+        // Gemma 4 utilise plusieurs tokens de fin: <eos>=1, <end_of_turn>=106, <pad>=0
+        // (cf. Gemma4Processor.eosTokenIds)
+        if Gemma4Processor.eosTokenIds.contains(tokenId) {
+            return true
+        }
+        if let eos = tokenizer.eosTokenId, Int(tokenId) == eos {
+            return true
+        }
+        return false
+    }
+
+    public enum MTPError: LocalizedError {
+        case unsupportedModel(String)
+        case cacheLayoutInvalid
+
+        public var errorDescription: String? {
+            switch self {
+            case .unsupportedModel(let t):
+                return "MTP requires Gemma4LLMModel, got \(t)"
+            case .cacheLayoutInvalid:
+                return "Cannot find both full_attention and sliding_attention concrete layers — model layout incompatible"
+            }
+        }
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4MultimodalLLMModel.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4MultimodalLLMModel.swift
@@ -73,11 +73,42 @@ public class Gemma4MultimodalLLMModel: Module, LLMModel, LoRAModel {
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         let cacheArray: [KVCache?]? = cache?.map { $0 as KVCache? }
+        let (inputsEmbeds, perLayerInputs) = prepareMultimodalEmbeds(inputs)
+        if let inputsEmbeds = inputsEmbeds {
+            return languageModel(
+                inputsEmbeds: inputsEmbeds,
+                cache: cacheArray,
+                perLayerInputs: perLayerInputs
+            )
+        }
+        return languageModel(inputs: inputs, cache: cacheArray)
+    }
 
-        // Si pas de media en attente, mode texte simple
+    /// Variante de `callAsFunction` qui retourne logits + hidden states (pre-norm) +
+    /// intermediates K/V — utilise par le path MTP speculative decoding.
+    public func forwardWithIntermediates(
+        _ inputs: MLXArray,
+        cache: [KVCache]?
+    ) -> LanguageForwardOutput {
+        let cacheArray: [KVCache?]? = cache?.map { $0 as KVCache? }
+        let (inputsEmbeds, perLayerInputs) = prepareMultimodalEmbeds(inputs)
+        if let inputsEmbeds = inputsEmbeds {
+            return languageModel.forwardWithIntermediates(
+                inputsEmbeds: inputsEmbeds,
+                cache: cacheArray,
+                perLayerInputs: perLayerInputs
+            )
+        }
+        return languageModel.forwardWithIntermediates(inputs: inputs, cache: cacheArray)
+    }
+
+    /// Construit les embeddings fusionnes (vision/video/audio) si du media est en attente.
+    /// Retourne (nil, nil) si pas de media — signal pour utiliser le path text-only.
+    /// Mute pendingX en nil apres consommation.
+    private func prepareMultimodalEmbeds(_ inputs: MLXArray) -> (MLXArray?, MLXArray?) {
         guard pendingPixelValues != nil || pendingVideoFrames != nil || pendingAudioFeatures != nil
               || pendingImageEmbeddings != nil || pendingAudioEmbeddings != nil else {
-            return languageModel(inputs: inputs, cache: cacheArray)
+            return (nil, nil)
         }
 
         // Mode multimodal: construire les embeddings fusionnes
@@ -193,11 +224,7 @@ public class Gemma4MultimodalLLMModel: Module, LLMModel, LoRAModel {
             pendingAudioMask = nil
         }
 
-        return languageModel(
-            inputsEmbeds: inputsEmbeds,
-            cache: cacheArray,
-            perLayerInputs: perLayerInputs
-        )
+        return (inputsEmbeds, perLayerInputs)
     }
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] {

--- a/Sources/Gemma4Swift/Speculative/Gemma4AssistantDraftModel.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4AssistantDraftModel.swift
@@ -61,6 +61,11 @@ public class Gemma4AssistantDraftModel: Module {
     private var inputEmbed: Embedding?
     private var inputEmbedScale: Float = 1.0
 
+    /// Si true, l'inference bypass le MaskedEmbedder et utilise les embeddings tied
+    /// (= meme calcul que `trainForward`). Necessaire apres fine-tuning car les
+    /// centroides du MaskedEmbedder ne sont pas mis a jour pendant le training.
+    public var useFullLMHead: Bool = false
+
     // Etat lie au round courant via setSharedKV(...)
     public private(set) var sharedKV: SharedKVStates?
     public private(set) var kvOffset: Int = 0
@@ -182,7 +187,7 @@ public class Gemma4AssistantDraftModel: Module {
 
         // 5. LM head
         let logits: MLXArray
-        if let masked = maskedEmbedding {
+        if let masked = maskedEmbedding, !useFullLMHead {
             // Sparse softmax via MaskedEmbedder, utilise les embeddings du drafter
             logits = masked(h, lmHeadWeight: model.embedTokens.weight)
         } else if config.tieWordEmbeddings {
@@ -193,6 +198,67 @@ public class Gemma4AssistantDraftModel: Module {
             fatalError("Aucun LM head disponible (ni masked_embedding, ni tied, ni lm_head)")
         }
 
+        return (lastHidden, logits)
+    }
+
+    // MARK: - Training forward (multi-position parallel)
+
+    /// Forward parallel sur L positions pour le training (distillation contre le target).
+    ///
+    /// Differences vs `callAsFunction`:
+    /// - Accepte un `startPosition` (offset RoPE de la 1ere query) au lieu d'une seule
+    ///   position constante. Les L queries recoivent des rotations [startPosition,
+    ///   startPosition+1, ..., startPosition+L-1].
+    /// - Accepte un mask explicite (typiquement `.causal` pour le training).
+    ///
+    /// - Parameters:
+    ///   - inputsEmbeds: `[B, L, 2 * backbone_hidden]` — concat(target_embed(token), target_hidden) par position
+    ///   - sharedKVStates: K/V partages du target (typiquement la sequence complete)
+    ///   - startPosition: position globale du 1er token (offset RoPE)
+    ///   - mask: typiquement `.causal` pour le training (chaque position p attend aux positions ≤ p)
+    /// - Returns: `(lastHidden: [B, L, backbone_hidden], logits: [B, L, vocab_size])`
+    public func trainForward(
+        inputsEmbeds: MLXArray,
+        sharedKVStates: SharedKVStates,
+        startPosition: Int,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode = .causal
+    ) -> (lastHidden: MLXArray, logits: MLXArray) {
+        let textCfg = config.textConfig
+        var h = preProjection(inputsEmbeds)
+
+        let layerTypes = textCfg.resolvedLayerTypes
+        for (i, layer) in model.layers.enumerated() {
+            let layerType = layerTypes[i]
+            guard let kv = sharedKVStates[layerType] else {
+                fatalError("sharedKVStates manque pour layer_type=\(layerType)")
+            }
+            let (output, _, _) = layer(
+                h,
+                mask: mask,
+                cache: nil,
+                perLayerInput: nil,
+                sharedKV: kv,
+                sharedOffset: startPosition
+            )
+            h = output
+        }
+        h = model.norm(h)
+        let lastHidden = postProjection(h)
+
+        // IMPORTANT: pour le training on bypass le MaskedEmbedder (utilise putAlong/scatter
+        // que MLX refuse de differentier — "Cannot calculate VJP with respect to indices").
+        // Le MaskedEmbedder est une optimisation d'inference sparse; pour le training
+        // on calcule les logits denses via les embeddings tied (= meme matrice de poids
+        // que masked_embedding utilise via lm_head_weight).
+        let logits: MLXArray
+        if config.tieWordEmbeddings {
+            logits = model.embedTokens.asLinear(h)
+        } else if let head = lmHead {
+            logits = head(h)
+        } else {
+            // Fallback: utiliser embed_tokens meme si tieWordEmbeddings=false
+            logits = model.embedTokens.asLinear(h)
+        }
         return (lastHidden, logits)
     }
 

--- a/Sources/Gemma4Swift/Speculative/Gemma4AssistantDraftModel.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4AssistantDraftModel.swift
@@ -288,7 +288,7 @@ public class Gemma4AssistantDraftModel: Module {
         }
         precondition(blockSize >= 2, "blockSize doit etre >= 2 (sinon aucun draft)")
 
-        var tok = MLXArray([Int32(lastBonus)]).reshaped(1, 1)  // [B=1, 1]
+        var tok = MLXArray([lastBonus]).reshaped(1, 1)  // [B=1, 1]
         var hPrev = hidden  // [B, 1, backbone]
         var tokens: [MLXArray] = []
 

--- a/Sources/Gemma4Swift/Speculative/Gemma4AssistantDraftModel.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4AssistantDraftModel.swift
@@ -1,0 +1,249 @@
+// Port de mlx-vlm/speculative/drafters/gemma4_assistant/gemma4_assistant.py
+//
+// Drafter de speculative decoding pour Gemma 4. Le drafter est un mini-transformer
+// (4 couches, hidden 256) dont TOUTES les couches sont kv_shared_only — elles
+// consomment les K/V des dernieres couches concretes du target (full + sliding).
+//
+// Pipeline d'un round MTP:
+//   1. setSharedKV(...) avec les K/V du target apres prefill
+//   2. draftBlock(...) genere block_size-1 tokens autoregressifs cote drafter
+//   3. Le target verifie [bonus | drafts] en un seul forward parallele
+//   4. Walk + rollback du cache target en cas de divergence
+
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Inner du drafter — mirror minimal de Gemma4TextModel sans per-layer inputs ni softcap.
+public class Gemma4AssistantDraftInner: Module {
+    public let config: Gemma4TextConfig
+
+    @ModuleInfo(key: "embed_tokens") public var embedTokens: Embedding
+    @ModuleInfo public var layers: [Gemma4DecoderLayer]
+    @ModuleInfo public var norm: RMSNorm
+
+    public init(_ config: Gemma4TextConfig) {
+        self.config = config
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.hiddenSize
+        )
+        self._layers.wrappedValue = (0 ..< config.numHiddenLayers).map { i in
+            Gemma4DecoderLayer(config, layerIdx: i, kvSharedOnly: true)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+}
+
+/// Etat partage du target — K/V des dernieres couches concretes par layer_type.
+public typealias SharedKVStates = [String: (keys: MLXArray, values: MLXArray)]
+
+/// Drafter MTP Gemma 4 Assistant.
+///
+/// Architecture:
+///   - `model: Gemma4AssistantDraftInner` (4-layer text transformer kv-shared-only)
+///   - `pre_projection: Linear(2 * backbone, hidden)`  — projete concat(target_embed, target_hidden)
+///   - `post_projection: Linear(hidden, backbone)`     — re-projete vers l'espace du target
+///   - `masked_embedding: MaskedEmbedder?`             — LM head sparse a centroides (si use_ordered_embeddings)
+///   - `lm_head: Linear?`                              — fallback dense si !tie_word_embeddings && !use_ordered_embeddings
+public class Gemma4AssistantDraftModel: Module {
+    public let config: Gemma4AssistantConfig
+
+    @ModuleInfo public var model: Gemma4AssistantDraftInner
+    @ModuleInfo(key: "pre_projection") public var preProjection: Linear
+    @ModuleInfo(key: "post_projection") public var postProjection: Linear
+    @ModuleInfo(key: "masked_embedding") public var maskedEmbedding: MaskedEmbedder?
+    @ModuleInfo(key: "lm_head") public var lmHead: Linear?
+
+    // Etat lie au target via bind(...)
+    private var inputEmbed: Embedding?
+    private var inputEmbedScale: Float = 1.0
+
+    // Etat lie au round courant via setSharedKV(...)
+    public private(set) var sharedKV: SharedKVStates?
+    public private(set) var kvOffset: Int = 0
+    public private(set) var position: Int = 0
+
+    public init(_ config: Gemma4AssistantConfig) {
+        self.config = config
+        let textCfg = config.textConfig
+
+        self._model.wrappedValue = Gemma4AssistantDraftInner(textCfg)
+        self._preProjection.wrappedValue = Linear(
+            2 * config.backboneHiddenSize, textCfg.hiddenSize, bias: false
+        )
+        self._postProjection.wrappedValue = Linear(
+            textCfg.hiddenSize, config.backboneHiddenSize, bias: false
+        )
+
+        if config.useOrderedEmbeddings {
+            self._maskedEmbedding.wrappedValue = MaskedEmbedder(config)
+        } else {
+            self._maskedEmbedding.wrappedValue = nil
+        }
+
+        if !config.tieWordEmbeddings {
+            self._lmHead.wrappedValue = Linear(
+                textCfg.hiddenSize, textCfg.vocabSize, bias: false
+            )
+        } else {
+            self._lmHead.wrappedValue = nil
+        }
+
+        super.init()
+    }
+
+    // MARK: - Binding au target
+
+    /// Lie le drafter au target — extrait l'embedding + scale du target pour
+    /// les utiliser dans `draftBlock` (les tokens sont embeddes dans l'espace du target
+    /// avant concat avec son hidden state).
+    @discardableResult
+    public func bind(target: Gemma4LanguageModel) -> Self {
+        self.inputEmbed = target.model.embedTokens
+        self.inputEmbedScale = pow(Float(target.config.hiddenSize), 0.5)
+        return self
+    }
+
+    /// Reset l'etat de round (sharedKV, position) — appele entre rounds MTP.
+    public func reset() {
+        self.sharedKV = nil
+        self.kvOffset = 0
+        self.position = 0
+    }
+
+    // MARK: - Etat partage du target
+
+    /// Stocke les K/V partages du target pour le round courant.
+    /// - Parameters:
+    ///   - sharedKVStates: dict layer_type -> (keys, values), shapes [B, numHeads, S, headDim]
+    ///   - kvOffset: longueur valide du cache target a ce point (= position d'ecriture du prochain token)
+    ///   - position: position des queries du drafter (default = kvOffset)
+    public func setSharedKV(
+        _ sharedKVStates: SharedKVStates,
+        kvOffset: Int,
+        position: Int? = nil
+    ) {
+        self.sharedKV = sharedKVStates
+        self.kvOffset = kvOffset
+        self.position = position ?? kvOffset
+    }
+
+    // MARK: - Forward
+
+    /// Forward d'un pas drafter.
+    /// - Parameters:
+    ///   - inputsEmbeds: `[B, L, 2 * backbone_hidden]` — concat(target_embed(token), target_hidden)
+    ///   - sharedKVStates: K/V partages du target par layer_type
+    ///   - position: position des queries (single int pour B=1 unbatched)
+    /// - Returns: `(lastHidden: [B, L, backbone_hidden], logits: [B, L, vocab_size])`
+    public func callAsFunction(
+        inputsEmbeds: MLXArray,
+        sharedKVStates: SharedKVStates,
+        position: Int
+    ) -> (lastHidden: MLXArray, logits: MLXArray) {
+        let textCfg = config.textConfig
+
+        // 1. Pre-projection: 2*backbone -> hidden
+        var h = preProjection(inputsEmbeds)
+
+        // 2. Forward a travers les layers, chaque couche consomme la K/V partagee
+        //    correspondant a son layer_type.
+        let layerTypes = textCfg.resolvedLayerTypes
+        for (i, layer) in model.layers.enumerated() {
+            let layerType = layerTypes[i]
+            guard let kv = sharedKVStates[layerType] else {
+                fatalError("sharedKVStates manque pour layer_type=\(layerType)")
+            }
+
+            // Pour le cas unbatched/no-padding (Phase 2 MVP), pas de masque additif.
+            // Les masques additifs (sliding window long, batch padding) seront ajoutes
+            // si necessaire en Phase 3.
+            let mask: MLXFast.ScaledDotProductAttentionMaskMode = .none
+
+            let (output, _, _) = layer(
+                h,
+                mask: mask,
+                cache: nil,
+                perLayerInput: nil,
+                sharedKV: kv,
+                sharedOffset: position
+            )
+            h = output
+        }
+
+        // 3. Norm finale
+        h = model.norm(h)
+
+        // 4. Post-projection: hidden -> backbone (pour servir d'input au prochain pas drafter)
+        let lastHidden = postProjection(h)
+
+        // 5. LM head
+        let logits: MLXArray
+        if let masked = maskedEmbedding {
+            // Sparse softmax via MaskedEmbedder, utilise les embeddings du drafter
+            logits = masked(h, lmHeadWeight: model.embedTokens.weight)
+        } else if config.tieWordEmbeddings {
+            logits = model.embedTokens.asLinear(h)
+        } else if let head = lmHead {
+            logits = head(h)
+        } else {
+            fatalError("Aucun LM head disponible (ni masked_embedding, ni tied, ni lm_head)")
+        }
+
+        return (lastHidden, logits)
+    }
+
+    // MARK: - Draft block (autoregressive K-step drafting)
+
+    /// Genere `blockSize - 1` tokens autoregressifs cote drafter.
+    ///
+    /// Pre-conditions: `bind(target:)` et `setSharedKV(...)` doivent avoir ete appelees.
+    ///
+    /// - Parameters:
+    ///   - lastBonus: dernier token accepte/sample par le target (debut du round).
+    ///   - hidden: hidden state du target a la position du `lastBonus`, shape `[B, 1, backbone_hidden]`.
+    ///   - blockSize: taille totale du bloc verify cote target (drafter genere `blockSize - 1` tokens).
+    ///   - sampler: fonction logits `[B, L, vocab]` -> tokens `[B, L]` (typiquement argmax pour greedy).
+    /// - Returns: tokens drafts `[B, blockSize - 1]` (Int32).
+    public func draftBlock(
+        lastBonus: Int32,
+        hidden: MLXArray,
+        blockSize: Int,
+        sampler: (MLXArray) -> MLXArray
+    ) -> MLXArray {
+        guard let sharedKVStates = sharedKV else {
+            fatalError("setSharedKV(...) doit etre appele avant draftBlock(...)")
+        }
+        guard let inputEmbed = inputEmbed else {
+            fatalError("bind(target:) doit etre appele avant draftBlock(...)")
+        }
+        precondition(blockSize >= 2, "blockSize doit etre >= 2 (sinon aucun draft)")
+
+        var tok = MLXArray([Int32(lastBonus)]).reshaped(1, 1)  // [B=1, 1]
+        var hPrev = hidden  // [B, 1, backbone]
+        var tokens: [MLXArray] = []
+
+        for _ in 0 ..< (blockSize - 1) {
+            // Embed le token courant dans l'espace du target (avec son scale)
+            var tokEmbed = inputEmbed(tok)
+            tokEmbed = tokEmbed * MLXArray(inputEmbedScale, dtype: tokEmbed.dtype)
+
+            // Concat avec hidden du target -> [B, 1, 2*backbone]
+            let inputsEmbeds = concatenated([tokEmbed, hPrev], axis: -1)
+
+            let out = self(
+                inputsEmbeds: inputsEmbeds,
+                sharedKVStates: sharedKVStates,
+                position: position
+            )
+            hPrev = out.lastHidden
+            tok = sampler(out.logits)  // [B, 1]
+            tokens.append(tok)
+        }
+
+        return concatenated(tokens, axis: 1)  // [B, blockSize - 1]
+    }
+}

--- a/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
@@ -116,6 +116,8 @@ public enum Gemma4DrafterTraining {
         public var batchSize: Int = 1
         public var seqLen: Int = 256
         public var stepsPerReport: Int = 10
+        public var stepsPerValid: Int = 0  // 0 = pas d'eval validation
+        public var validBatches: Int = 8   // nb de batches a evaluer sur la valid
         public var saveEvery: Int = 100
         public var weightsURL: URL? = nil
 
@@ -138,6 +140,7 @@ public enum Gemma4DrafterTraining {
         drafter: Gemma4AssistantDraftModel,
         target: Gemma4LanguageModel,
         tokenizedSamples: [[Int]],
+        validSamples: [[Int]] = [],
         lastFullCacheIdx: Int,
         lastSlidingCacheIdx: Int,
         optimizer: any Optimizer,
@@ -150,20 +153,25 @@ public enum Gemma4DrafterTraining {
 
         // Decouper les samples en chunks de seqLen (descendants un par un, pas de batch interne)
         let seqLen = config.seqLen
-        var chunks: [[Int]] = []
-        for sample in tokenizedSamples {
-            var idx = 0
-            while idx + seqLen <= sample.count {
-                chunks.append(Array(sample[idx ..< idx + seqLen]))
-                idx += seqLen
+        func chunkify(_ samples: [[Int]]) -> [[Int]] {
+            var out: [[Int]] = []
+            for sample in samples {
+                var idx = 0
+                while idx + seqLen <= sample.count {
+                    out.append(Array(sample[idx ..< idx + seqLen]))
+                    idx += seqLen
+                }
             }
+            return out
         }
+        let chunks = chunkify(tokenizedSamples)
+        let validChunks = chunkify(validSamples)
         guard !chunks.isEmpty else {
             throw NSError(domain: "DrafterTraining", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "No chunks of length \(seqLen) found in samples"
             ])
         }
-        print("[drafter-train] \(chunks.count) chunks de longueur \(seqLen)")
+        print("[drafter-train] \(chunks.count) train chunks, \(validChunks.count) valid chunks (longueur \(seqLen))")
 
         // valueAndGrad sur le DRAFTER seulement
         // batch = [batchTokens] (single MLXArray in array)
@@ -208,10 +216,41 @@ public enum Gemma4DrafterTraining {
                 let avgLoss = losses.suffix(config.stepsPerReport).reduce(0, +) / Float(config.stepsPerReport)
                 let now = Date.timeIntervalSinceReferenceDate
                 let iterPerSec = Double(config.stepsPerReport) / (now - iterStart)
-                print(String(format: "[drafter-train] iter %d/%d  loss=%.4f  %.1f it/s",
+                print(String(format: "[drafter-train] iter %d/%d  train_loss=%.4f  %.1f it/s",
                              iter + 1, config.iterations, avgLoss, iterPerSec))
                 progress(iter + 1, avgLoss)
                 iterStart = now
+            }
+
+            // Validation eval (no grad)
+            if config.stepsPerValid > 0,
+               !validChunks.isEmpty,
+               (iter + 1) % config.stepsPerValid == 0 {
+                drafter.train(false)
+                var valLosses: [Float] = []
+                let nValBatches = min(config.validBatches, validChunks.count / batchSize)
+                for vb in 0 ..< max(nValBatches, 1) {
+                    var flat: [Int32] = []
+                    flat.reserveCapacity(batchSize * seqLen)
+                    for j in 0 ..< batchSize {
+                        let idx = (vb * batchSize + j) % validChunks.count
+                        flat.append(contentsOf: validChunks[idx].map { Int32($0) })
+                    }
+                    let valBatch = MLXArray(flat).reshaped(batchSize, seqLen)
+                    let (vloss, _) = drafterLoss(
+                        drafter: drafter, target: target,
+                        batchTokens: valBatch,
+                        lastFullCacheIdx: lastFullCacheIdx,
+                        lastSlidingCacheIdx: lastSlidingCacheIdx
+                    )
+                    eval(vloss)
+                    valLosses.append(vloss.item(Float.self))
+                }
+                drafter.train()
+                let avgValLoss = valLosses.reduce(0, +) / Float(max(valLosses.count, 1))
+                print(String(format: "[drafter-train] iter %d/%d  valid_loss=%.4f  (n=%d batches)",
+                             iter + 1, config.iterations, avgValLoss, valLosses.count))
+                iterStart = Date.timeIntervalSinceReferenceDate
             }
 
             // Save checkpoint

--- a/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
@@ -181,12 +181,16 @@ public enum Gemma4DrafterTraining {
         var losses: [Float] = []
         var iterStart = Date.timeIntervalSinceReferenceDate
 
+        let batchSize = max(config.batchSize, 1)
         for iter in 0 ..< config.iterations {
-            // Sample un chunk au hasard
-            let chunk = chunks.randomElement()!
-
-            // batch [1, seqLen]
-            let batchTokens = MLXArray(chunk.map { Int32($0) }).reshaped(1, seqLen)
+            // Sample batchSize chunks au hasard (tous de longueur fixe seqLen → pas de padding)
+            var flatTokens: [Int32] = []
+            flatTokens.reserveCapacity(batchSize * seqLen)
+            for _ in 0 ..< batchSize {
+                let chunk = chunks.randomElement()!
+                flatTokens.append(contentsOf: chunk.map { Int32($0) })
+            }
+            let batchTokens = MLXArray(flatTokens).reshaped(batchSize, seqLen)
 
             // Forward + backward
             let (results, grads) = lossValueGrad(drafter, [batchTokens])

--- a/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
@@ -1,0 +1,228 @@
+// Training loop pour le drafter MTP (Gemma 4 Assistant) via auto-distillation.
+//
+// Idee: target frozen, drafter trainable. Pour chaque batch:
+//   1. Forward target (no grad) sur la sequence -> hidden states + sharedKV
+//   2. Construit (bonus_token, prev_hidden) pairs pour chaque position
+//   3. Forward drafter (avec grad) en parallele avec mask causal
+//   4. Loss = cross-entropy entre drafter logits et ground-truth next token
+//
+// Le drafter apprend a predire EXACTEMENT comme le target — c'est ce qui
+// maximise l'acceptance rate au moment de l'inference MTP.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXOptimizers
+
+public enum Gemma4DrafterTraining {
+
+    // MARK: - Loss function
+
+    /// Computes drafter training loss for a single batch.
+    /// - Parameters:
+    ///   - drafter: drafter trainable
+    ///   - target: target frozen, deja bind() au drafter
+    ///   - batchTokens: `[B, L]` tokens entiers (pas de padding interne — tous samples meme longueur)
+    ///   - lastFullCacheIdx: index dans target's concrete layers de la derniere full attention
+    ///   - lastSlidingCacheIdx: idem pour sliding
+    /// - Returns: `(loss, ntoks)` ou ntoks = nombre de positions qui contribuent a la loss
+    public static func drafterLoss(
+        drafter: Gemma4AssistantDraftModel,
+        target: Gemma4LanguageModel,
+        batchTokens: MLXArray,
+        lastFullCacheIdx: Int,
+        lastSlidingCacheIdx: Int
+    ) -> (loss: MLXArray, ntoks: MLXArray) {
+        let L = batchTokens.dim(1)
+        precondition(L >= 3, "batch sequence length doit etre >= 3 (need positions p, p+1, p+2)")
+
+        // 1. Target forward (no grad) — pre-norm hidden + sharedKV + LOGITS
+        let targetOut = target.forwardWithIntermediates(inputs: batchTokens)
+        // stopGradient sur tout ce qui vient du target — frozen, pas de backprop
+        let hiddens = stopGradient(targetOut.preNormHiddenStates)  // [B, L, backbone]
+
+        // Self-distillation targets: utiliser argmax(target_logits) plutot que ground truth.
+        // C'est ce qui maximise l'acceptance rate au moment de l'inference MTP — le drafter
+        // doit MATCH le target, pas la verite terrain.
+        let targetArgmax = stopGradient(argMax(targetOut.logits, axis: -1))  // [B, L]
+
+        guard let fullKV = targetOut.intermediates[lastFullCacheIdx],
+              let slidingKV = targetOut.intermediates[lastSlidingCacheIdx] else {
+            fatalError("Cannot extract shared K/V from target intermediates")
+        }
+        let sharedKV: SharedKVStates = [
+            "full_attention": (
+                keys: stopGradient(fullKV.keys),
+                values: stopGradient(fullKV.values)
+            ),
+            "sliding_attention": (
+                keys: stopGradient(slidingKV.keys),
+                values: stopGradient(slidingKV.values)
+            ),
+        ]
+
+        // 2. Construire les (bonus_token, prev_hidden) pour positions 1..L-1
+        // bonus[p] = batchTokens[p] (token a la position p, qu'on traite comme bonus)
+        // prev_hidden[p] = hiddens[p-1] (etat avant de voir token p)
+        let bonusTokens = batchTokens[0..., 1...]                          // [B, L-1]
+        let prevHiddens = hiddens[0..., .stride(to: -1)]                   // [B, L-1, backbone]
+
+        let scale = pow(Float(target.config.hiddenSize), 0.5)
+        var bonusEmbeds = target.model.embedTokens(bonusTokens)
+        bonusEmbeds = bonusEmbeds * MLXArray(scale, dtype: bonusEmbeds.dtype)
+        bonusEmbeds = stopGradient(bonusEmbeds)
+
+        let drafterInput = concatenated([bonusEmbeds, prevHiddens], axis: -1)
+        // drafterInput: [B, L-1, 2*backbone]
+
+        // 3. Drafter forward (avec grad) en parallele, mask causal
+        let drafterOut = drafter.trainForward(
+            inputsEmbeds: drafterInput,
+            sharedKVStates: sharedKV,
+            startPosition: 1,
+            mask: .causal
+        )
+        // drafterOut.logits: [B, L-1, vocab]
+
+        // 4. Loss: drafter at position p predicts what target predicts at position p+1
+        // (= argmax of target_logits[p+1]). Pour input index i in 0..L-2 (= position p+1 = i+1),
+        // drafter predit le token a position p+2 = i+2. La cible distillation est
+        // argmax(target_logits[i+1]) qui represente "ce que target predit apres avoir vu
+        // tokens 0..i+1" = predict position i+2.
+        let validLogits = drafterOut.logits[0..., .stride(to: -1), 0...].asType(.float32)
+        // [B, L-2, vocab]
+
+        // Self-distillation targets: argmax(target_logits) at positions 1..L-2
+        // = predicts "what comes next at position 2..L-1"
+        let targets = targetArgmax[0..., 1 ..< (L - 1)]  // [B, L-2]
+
+        let logProbs = MLXNN.logSoftmax(validLogits, axis: -1)
+        // gather log_probs at target positions
+        let targetExpanded = expandedDimensions(targets, axis: -1)  // [B, L-2, 1]
+        let pickedLogProbs = takeAlong(logProbs, targetExpanded.asType(.int32), axis: -1)
+            .squeezed(axis: -1)
+        // [B, L-2]
+
+        let loss = -pickedLogProbs.mean()
+        let ntoks = MLXArray(Float(targets.size))
+        return (loss, ntoks)
+    }
+
+    // MARK: - Training loop
+
+    public struct TrainConfig {
+        public var iterations: Int = 100
+        public var batchSize: Int = 1
+        public var seqLen: Int = 256
+        public var stepsPerReport: Int = 10
+        public var saveEvery: Int = 100
+        public var weightsURL: URL? = nil
+
+        public init() {}
+    }
+
+    /// Entrainement par auto-distillation contre le target.
+    ///
+    /// - Parameters:
+    ///   - drafter: drafter Module avec poids initiaux deja charges (typiquement les poids
+    ///     pretrained du Google Assistant model, on fine-tune par dessus)
+    ///   - target: target frozen — ses parametres ne doivent PAS etre modifies
+    ///   - tokenizedSamples: liste de sequences de tokens (chaque sample = un long texte tokenise).
+    ///     Sera decoupe en chunks de `seqLen` pour les batches.
+    ///   - lastFullCacheIdx, lastSlidingCacheIdx: indices des dernieres couches concretes par type
+    ///     dans le target (utilises pour extraire la sharedKV)
+    ///   - optimizer: typiquement Adam(lr=1e-4)
+    ///   - config: hyperparametres
+    public static func trainDrafter(
+        drafter: Gemma4AssistantDraftModel,
+        target: Gemma4LanguageModel,
+        tokenizedSamples: [[Int]],
+        lastFullCacheIdx: Int,
+        lastSlidingCacheIdx: Int,
+        optimizer: any Optimizer,
+        config: TrainConfig,
+        progress: (Int, Float) -> Void = { _, _ in }
+    ) throws {
+        target.train(false)   // target en eval mode (frozen)
+        target.freeze()
+        drafter.train()       // drafter en train mode
+
+        // Decouper les samples en chunks de seqLen (descendants un par un, pas de batch interne)
+        let seqLen = config.seqLen
+        var chunks: [[Int]] = []
+        for sample in tokenizedSamples {
+            var idx = 0
+            while idx + seqLen <= sample.count {
+                chunks.append(Array(sample[idx ..< idx + seqLen]))
+                idx += seqLen
+            }
+        }
+        guard !chunks.isEmpty else {
+            throw NSError(domain: "DrafterTraining", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "No chunks of length \(seqLen) found in samples"
+            ])
+        }
+        print("[drafter-train] \(chunks.count) chunks de longueur \(seqLen)")
+
+        // valueAndGrad sur le DRAFTER seulement
+        // batch = [batchTokens] (single MLXArray in array)
+        let lossValueGrad = valueAndGrad(model: drafter) { (drafter: Gemma4AssistantDraftModel, arrays: [MLXArray]) -> [MLXArray] in
+            let (loss, ntoks) = drafterLoss(
+                drafter: drafter,
+                target: target,
+                batchTokens: arrays[0],
+                lastFullCacheIdx: lastFullCacheIdx,
+                lastSlidingCacheIdx: lastSlidingCacheIdx
+            )
+            return [loss, ntoks]
+        }
+
+        var losses: [Float] = []
+        var iterStart = Date.timeIntervalSinceReferenceDate
+
+        for iter in 0 ..< config.iterations {
+            // Sample un chunk au hasard
+            let chunk = chunks.randomElement()!
+
+            // batch [1, seqLen]
+            let batchTokens = MLXArray(chunk.map { Int32($0) }).reshaped(1, seqLen)
+
+            // Forward + backward
+            let (results, grads) = lossValueGrad(drafter, [batchTokens])
+            let lossValue = results[0]
+            let _ = results[1]  // ntoks (unused for now)
+
+            optimizer.update(model: drafter, gradients: grads)
+            eval(drafter, optimizer, lossValue)
+
+            let lf = lossValue.item(Float.self)
+            losses.append(lf)
+
+            // Report
+            if (iter + 1) % config.stepsPerReport == 0 {
+                let avgLoss = losses.suffix(config.stepsPerReport).reduce(0, +) / Float(config.stepsPerReport)
+                let now = Date.timeIntervalSinceReferenceDate
+                let iterPerSec = Double(config.stepsPerReport) / (now - iterStart)
+                print(String(format: "[drafter-train] iter %d/%d  loss=%.4f  %.1f it/s",
+                             iter + 1, config.iterations, avgLoss, iterPerSec))
+                progress(iter + 1, avgLoss)
+                iterStart = now
+            }
+
+            // Save checkpoint
+            if let url = config.weightsURL, (iter + 1) % config.saveEvery == 0 {
+                let params = Dictionary(uniqueKeysWithValues: drafter.parameters().flattened())
+                try save(arrays: params, url: url)
+                print("[drafter-train] checkpoint saved to \(url.path)")
+            }
+        }
+
+        // Save final
+        if let url = config.weightsURL {
+            let params = Dictionary(uniqueKeysWithValues: drafter.parameters().flattened())
+            try save(arrays: params, url: url)
+            print("[drafter-train] final weights saved to \(url.path)")
+        }
+    }
+}

--- a/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
+++ b/Sources/Gemma4Swift/Speculative/Gemma4DrafterTraining.swift
@@ -188,6 +188,7 @@ public enum Gemma4DrafterTraining {
 
         var losses: [Float] = []
         var iterStart = Date.timeIntervalSinceReferenceDate
+        var bestValidLoss: Float = .infinity
 
         let batchSize = max(config.batchSize, 1)
         for iter in 0 ..< config.iterations {
@@ -248,8 +249,19 @@ public enum Gemma4DrafterTraining {
                 }
                 drafter.train()
                 let avgValLoss = valLosses.reduce(0, +) / Float(max(valLosses.count, 1))
-                print(String(format: "[drafter-train] iter %d/%d  valid_loss=%.4f  (n=%d batches)",
-                             iter + 1, config.iterations, avgValLoss, valLosses.count))
+                let isBest = avgValLoss < bestValidLoss
+                let marker = isBest ? "  [BEST]" : ""
+                print(String(format: "[drafter-train] iter %d/%d  valid_loss=%.4f  (n=%d batches)%@",
+                             iter + 1, config.iterations, avgValLoss, valLosses.count, marker))
+                if isBest {
+                    bestValidLoss = avgValLoss
+                    if let url = config.weightsURL {
+                        let bestURL = url.deletingPathExtension()
+                            .appendingPathExtension("best.safetensors")
+                        let params = Dictionary(uniqueKeysWithValues: drafter.parameters().flattened())
+                        try save(arrays: params, url: bestURL)
+                    }
+                }
                 iterStart = Date.timeIntervalSinceReferenceDate
             }
 
@@ -266,6 +278,11 @@ public enum Gemma4DrafterTraining {
             let params = Dictionary(uniqueKeysWithValues: drafter.parameters().flattened())
             try save(arrays: params, url: url)
             print("[drafter-train] final weights saved to \(url.path)")
+            if bestValidLoss.isFinite {
+                let bestURL = url.deletingPathExtension().appendingPathExtension("best.safetensors")
+                print(String(format: "[drafter-train] best valid_loss=%.4f saved to %@",
+                             bestValidLoss, bestURL.path))
+            }
         }
     }
 }

--- a/Sources/Gemma4Swift/Speculative/MaskedEmbedder.swift
+++ b/Sources/Gemma4Swift/Speculative/MaskedEmbedder.swift
@@ -1,0 +1,91 @@
+// Port de mlx-vlm/speculative/drafters/gemma4_assistant/masked_embedder.py
+//
+// Centroid-routed sparse softmax: au lieu de calculer hidden @ embed.T sur tout
+// le vocab (262144 tokens, couteux pour un drafter avec hidden_size=256), le
+// drafter score 2048 clusters de tokens via une couche `centroids`, selectionne
+// les top-K (32) clusters, et calcule les logits seulement pour les tokens de
+// ces clusters (32 * vocab_size_per_centroid = 32 * 128 = 4096 tokens).
+// Les autres positions du vocab sont masquees a min - 1.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// LM head sparse a centroides pour le drafter Gemma 4 Assistant.
+public class MaskedEmbedder: Module {
+    public let hiddenSize: Int
+    public let vocabSize: Int
+    public let numCentroids: Int
+    public let topK: Int
+    public let vocabSizePerCentroid: Int
+
+    @ModuleInfo var centroids: Linear  // [num_centroids, hidden_size]
+    @ParameterInfo(key: "token_ordering") var tokenOrdering: MLXArray  // [vocab_size], int32
+
+    public init(_ config: Gemma4AssistantConfig) {
+        self.hiddenSize = config.textConfig.hiddenSize
+        self.vocabSize = config.textConfig.vocabSize
+        self.numCentroids = config.numCentroids
+        self.topK = config.centroidIntermediateTopK
+        self.vocabSizePerCentroid = config.textConfig.vocabSize / config.numCentroids
+
+        self._centroids.wrappedValue = Linear(hiddenSize, numCentroids, bias: false)
+        self._tokenOrdering.wrappedValue = MLXArray.zeros([config.textConfig.vocabSize], type: Int32.self)
+
+        super.init()
+    }
+
+    /// Calcule les logits sparses sur le vocab complet.
+    ///
+    /// - Parameters:
+    ///   - hidden: hidden states `[B, L, hidden_size]`
+    ///   - lmHeadWeight: matrice d'embedding tied `[vocab_size, hidden_size]`
+    /// - Returns: logits `[B, L, vocab_size]`. Les positions non-selectionnees
+    ///   sont masquees a `min(selected_logits) - 1`.
+    public func callAsFunction(_ hidden: MLXArray, lmHeadWeight: MLXArray) -> MLXArray {
+        let B = hidden.dim(0)
+        let L = hidden.dim(1)
+
+        // 1. Scores des centroides [B, L, num_centroids]
+        let centroidLogits = centroids(hidden)
+
+        // 2. Top-K indices de clusters [B, L, top_k]
+        // argPartition(kth=N-K) place le (N-K)-eme element a sa position triee.
+        // Les indices >= N-K sont donc les top-K plus grands.
+        let partitioned = argPartition(centroidLogits, kth: numCentroids - topK, axis: -1)
+        let topkIdx = partitioned[.ellipsis, (numCentroids - topK)...]  // [B, L, top_k]
+
+        // 3. Reshape token_ordering en [num_centroids, vocab_size_per_centroid]
+        let ordering = tokenOrdering.reshaped(numCentroids, vocabSizePerCentroid)
+
+        // 4. Gather: pour chaque cluster selectionne, recuperer ses token IDs
+        // ordering.take(topkIdx, axis: 0) → [B, L, top_k, vocab_size_per_centroid]
+        let selectedCanonical = ordering.take(topkIdx, axis: 0)
+
+        // 5. Embedding lookup pour les tokens selectionnes
+        // flat_idx [B*L*top_k*vsc] → selectedEmb [B, L, top_k*vsc, hidden_size]
+        let flatIdx = selectedCanonical.reshaped(-1)
+        let selectedEmb = lmHeadWeight.take(flatIdx, axis: 0)
+            .reshaped(B, L, topK * vocabSizePerCentroid, hiddenSize)
+
+        // 6. selected_logits = h @ E.T
+        // hidden[..., None, :] [B, L, 1, hidden] @ selectedEmb.T [B, L, hidden, top_k*vsc]
+        // → [B, L, 1, top_k*vsc] → squeeze → [B, L, top_k*vsc]
+        let hiddenExpanded = expandedDimensions(hidden, axis: -2)
+        let embT = selectedEmb.swappedAxes(-1, -2)
+        let selectedLogits = matmul(hiddenExpanded, embT).squeezed(axis: -2)
+
+        // 7. Mask value = min des logits selectionnes - 1
+        let maskValueArr = selectedLogits.min() - MLXArray(Float(1.0))
+
+        // 8. Allouer le tenseur full-vocab rempli avec mask_value
+        let scatterIdx = selectedCanonical.reshaped(B, L, -1)  // [B, L, top_k*vsc]
+        let out = MLXArray.full(
+            [B, L, vocabSize],
+            values: maskValueArr.asType(hidden.dtype)
+        )
+
+        // 9. Scatter selected_logits aux positions canoniques du vocab
+        return putAlong(out, scatterIdx, values: selectedLogits, axis: -1)
+    }
+}

--- a/Sources/Gemma4Swift/Speculative/SpeculativeWalk.swift
+++ b/Sources/Gemma4Swift/Speculative/SpeculativeWalk.swift
@@ -1,0 +1,59 @@
+// Port de mlx-vlm/generate.py:_speculative_walk
+//
+// Marche speculative greedy: accepte les tokens du drafter jusqu'a la premiere
+// divergence avec le sample du target, puis prend la prediction du target a ce
+// point. Garantit que la sortie finale est strictement equivalente a la
+// generation greedy du target (sans speculation).
+
+import Foundation
+
+public enum SpeculativeWalk {
+
+    /// Resultat d'un walk speculative.
+    public struct Result {
+        /// Nombre de drafts acceptes (0..n_draft).
+        public let accepted: Int
+        /// Tokens emis ce round: drafts acceptes + token de correction/bonus du target.
+        /// Toujours de longueur `accepted + 1` (avant truncation par budget).
+        public let newTokens: [Int32]
+    }
+
+    /// Effectue le walk greedy.
+    ///
+    /// - Parameters:
+    ///   - drafts: tokens proposes par le drafter, longueur `K-1`.
+    ///   - targets: tokens predits par le target sur les positions `[bonus | drafts]`,
+    ///     longueur `K`. `targets[i]` est la prediction du target apres avoir vu
+    ///     les positions `0..i` du verify-input.
+    ///   - budget: nombre maximum de tokens a retourner (typiquement `max_tokens - emitted`).
+    /// - Returns: `(accepted, new_tokens)`. `new_tokens` a longueur `min(accepted + 1, budget)`.
+    public static func walk(
+        drafts: [Int32],
+        targets: [Int32],
+        budget: Int
+    ) -> Result {
+        precondition(targets.count == drafts.count + 1,
+                     "targets doit faire drafts.count + 1 (verify-input = [bonus | drafts])")
+        precondition(budget >= 0)
+
+        // Trouver le premier i ou drafts[i] != targets[i]; si aucun, accepted = drafts.count
+        var accepted = drafts.count
+        for i in 0 ..< drafts.count {
+            if drafts[i] != targets[i] {
+                accepted = i
+                break
+            }
+        }
+
+        // Tokens emis: drafts acceptes + correction/bonus du target a la position de divergence
+        var emitted = Array(drafts.prefix(accepted))
+        emitted.append(targets[accepted])
+
+        // Truncate au budget
+        if emitted.count > budget {
+            emitted = Array(emitted.prefix(budget))
+        }
+
+        return Result(accepted: accepted, newTokens: emitted)
+    }
+}

--- a/Sources/Gemma4Swift/TextModel/Gemma4Attention.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4Attention.swift
@@ -22,21 +22,25 @@ public class Gemma4Attention: Module {
     let numKVHeads: Int
     let useKEqV: Bool
     let isKvSharedLayer: Bool
+    /// Si true, la couche n'a JAMAIS ses propres K/V (drafter Assistant) — on skip
+    /// k_proj/v_proj/k_norm/v_norm a l'init et on force le path sharedKV au forward.
+    let kvSharedOnly: Bool
     let scale: Float
 
     @ModuleInfo(key: "q_proj") var qProj: Linear
-    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear?
     @ModuleInfo(key: "v_proj") var vProj: Linear?
     @ModuleInfo(key: "o_proj") var oProj: Linear
     @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
-    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
-    @ModuleInfo(key: "v_norm") var vNorm: RMSNormNoScale
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm?
+    @ModuleInfo(key: "v_norm") var vNorm: RMSNormNoScale?
 
     let rope: RoPEWrapper
 
-    public init(_ config: Gemma4TextConfig, layerIdx: Int) {
+    public init(_ config: Gemma4TextConfig, layerIdx: Int, kvSharedOnly: Bool = false) {
         self.config = config
         self.layerIdx = layerIdx
+        self.kvSharedOnly = kvSharedOnly
 
         let layerTypes = config.resolvedLayerTypes
         self.layerType = layerTypes[layerIdx]
@@ -63,17 +67,25 @@ public class Gemma4Attention: Module {
         self.scale = 1.0
 
         self._qProj.wrappedValue = Linear(dim, numHeads * headDim, bias: false)
-        self._kProj.wrappedValue = Linear(dim, numKVHeads * headDim, bias: false)
-        if !useKEqV {
-            self._vProj.wrappedValue = Linear(dim, numKVHeads * headDim, bias: false)
-        } else {
-            self._vProj.wrappedValue = nil
-        }
         self._oProj.wrappedValue = Linear(numHeads * headDim, dim, bias: false)
-
         self._qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
-        self._kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
-        self._vNorm.wrappedValue = RMSNormNoScale(eps: config.rmsNormEps)
+
+        if kvSharedOnly {
+            // Drafter Assistant: pas de K/V propres, jamais. Skip les modules associes.
+            self._kProj.wrappedValue = nil
+            self._vProj.wrappedValue = nil
+            self._kNorm.wrappedValue = nil
+            self._vNorm.wrappedValue = nil
+        } else {
+            self._kProj.wrappedValue = Linear(dim, numKVHeads * headDim, bias: false)
+            if !useKEqV {
+                self._vProj.wrappedValue = Linear(dim, numKVHeads * headDim, bias: false)
+            } else {
+                self._vProj.wrappedValue = nil
+            }
+            self._kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+            self._vNorm.wrappedValue = RMSNormNoScale(eps: config.rmsNormEps)
+        }
 
         // KV sharing
         let firstKvSharedLayerIdx = config.firstKvSharedLayerIdx
@@ -140,8 +152,13 @@ public class Gemma4Attention: Module {
             return (oProj(output), (keys, values), effectiveOffset)
 
         } else if isKvSharedLayer, let cache = cache {
-            // KV sharing avec cache (inference): reutiliser le cache existant
-            effectiveOffset = cache.offset
+            // KV sharing avec cache (inference): reutiliser le cache existant.
+            // IMPORTANT: cache.offset a deja ete incremente de L par la couche concrete
+            // source (qui s'execute avant nous dans le meme forward). Nos queries
+            // correspondent aux positions globales [cache.offset - L, ..., cache.offset - 1],
+            // donc RoPE doit etre applique a (cache.offset - L), pas cache.offset.
+            // (Equivaut a `offset` parameter passe par la textModel cote Python.)
+            effectiveOffset = cache.offset - L
             queries = rope(queries, offset: effectiveOffset)
 
             // TurboQuant shared
@@ -223,6 +240,9 @@ public class Gemma4Attention: Module {
     private func computeKV(
         x: MLXArray, B: Int, L: Int
     ) -> (keys: MLXArray, values: MLXArray) {
+        guard let kProj = kProj, let kNorm = kNorm, let vNorm = vNorm else {
+            fatalError("computeKV appele sur une couche kvSharedOnly — sharedKV doit etre fourni externe")
+        }
         var keys = kProj(x).reshaped(B, L, numKVHeads, headDim)
 
         // K=V: values sont le raw k_proj output (avant k_norm)

--- a/Sources/Gemma4Swift/TextModel/Gemma4DecoderLayer.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4DecoderLayer.swift
@@ -37,14 +37,14 @@ public class Gemma4DecoderLayer: Module {
     // Layer scalar
     @ModuleInfo(key: "layer_scalar") var layerScalar: MLXArray
 
-    public init(_ config: Gemma4TextConfig, layerIdx: Int) {
+    public init(_ config: Gemma4TextConfig, layerIdx: Int, kvSharedOnly: Bool = false) {
         self.config = config
         self.layerIdx = layerIdx
         self.layerType = config.resolvedLayerTypes[layerIdx]
         self.hiddenSizePerLayerInput = config.hiddenSizePerLayerInput
         self.enableMoe = config.enableMoeBlock
 
-        self._selfAttn.wrappedValue = Gemma4Attention(config, layerIdx: layerIdx)
+        self._selfAttn.wrappedValue = Gemma4Attention(config, layerIdx: layerIdx, kvSharedOnly: kvSharedOnly)
         self._mlp.wrappedValue = Gemma4MLP(config, layerIdx: layerIdx)
 
         self._inputLayernorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)

--- a/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
@@ -6,12 +6,20 @@ import MLXFast
 import MLXNN
 import MLXLMCommon
 
+/// Sortie complete d'un forward du Gemma4LanguageModel.
+/// Utilise par le path MTP pour exposer logits + hidden state + K/V intermediaires.
+public struct LanguageForwardOutput {
+    public let logits: MLXArray
+    public let hiddenStates: MLXArray
+    public let intermediates: [LayerIntermediate?]
+}
+
 /// Modele de langage Gemma 4 complet (text model + logit head + softcapping)
 public class Gemma4LanguageModel: Module {
-    let config: Gemma4TextConfig
+    public let config: Gemma4TextConfig
     let finalLogitSoftcapping: Float?
 
-    @ModuleInfo var model: Gemma4TextModel
+    @ModuleInfo public var model: Gemma4TextModel
 
     public init(_ config: Gemma4TextConfig) {
         self.config = config
@@ -43,6 +51,34 @@ public class Gemma4LanguageModel: Module {
         }
 
         return out
+    }
+
+    /// Forward qui retourne logits + hidden states + K/V intermediaires par couche.
+    /// Utilise par le path MTP : le drafter consomme `hiddenStates` et `intermediates`.
+    /// Le `callAsFunction` standard reste inchange.
+    public func forwardWithIntermediates(
+        inputs: MLXArray? = nil,
+        inputsEmbeds: MLXArray? = nil,
+        cache: [KVCache?]? = nil,
+        perLayerInputs: MLXArray? = nil
+    ) -> LanguageForwardOutput {
+        let textOut = model.forwardCollectingIntermediates(
+            inputs: inputs,
+            inputsEmbeds: inputsEmbeds,
+            cache: cache,
+            perLayerInputs: perLayerInputs
+        )
+
+        var logits = model.embedTokens.asLinear(textOut.hidden)
+        if let softcap = finalLogitSoftcapping {
+            logits = tanh(logits / softcap) * softcap
+        }
+
+        return LanguageForwardOutput(
+            logits: logits,
+            hiddenStates: textOut.hidden,
+            intermediates: textOut.intermediates
+        )
     }
 
     /// Estime si TurboQuant est benefique pour cette architecture.

--- a/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
@@ -10,7 +10,10 @@ import MLXLMCommon
 /// Utilise par le path MTP pour exposer logits + hidden state + K/V intermediaires.
 public struct LanguageForwardOutput {
     public let logits: MLXArray
+    /// Hidden APRES final RMSNorm (= input du lm_head).
     public let hiddenStates: MLXArray
+    /// Hidden AVANT final RMSNorm — c'est ce que le drafter MTP attend.
+    public let preNormHiddenStates: MLXArray
     public let intermediates: [LayerIntermediate?]
 }
 
@@ -77,6 +80,7 @@ public class Gemma4LanguageModel: Module {
         return LanguageForwardOutput(
             logits: logits,
             hiddenStates: textOut.hidden,
+            preNormHiddenStates: textOut.preNormHidden,
             intermediates: textOut.intermediates
         )
     }

--- a/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
@@ -16,7 +16,16 @@ public struct LayerIntermediate {
 }
 
 public struct TextForwardOutput {
+    /// Sortie du dernier decoder layer APRES le final RMSNorm.
+    /// Utilise pour calculer les logits (lm_head sur cette valeur).
     public let hidden: MLXArray
+
+    /// Sortie du dernier decoder layer AVANT le final RMSNorm.
+    /// IMPORTANT: c'est cette valeur que le drafter Assistant attend en entree
+    /// (le `pre_projection` du drafter a ete entraine contre cette hidden pre-norm).
+    /// Voir mlx_vlm/models/gemma4/language.py: "captured BEFORE the final RMSNorm".
+    public let preNormHidden: MLXArray
+
     public let intermediates: [LayerIntermediate?]
 }
 
@@ -265,6 +274,14 @@ public class Gemma4TextModel: Module {
             return LayerIntermediate(keys: entry.kv.keys, values: entry.kv.values, offset: entry.offset)
         }
 
-        return TextForwardOutput(hidden: norm(h), intermediates: publicIntermediates)
+        // Capture h pre-norm pour le drafter MTP, puis applique norm pour les logits standard.
+        let preNormHidden = h
+        let normedHidden = norm(h)
+
+        return TextForwardOutput(
+            hidden: normedHidden,
+            preNormHidden: preNormHidden,
+            intermediates: publicIntermediates
+        )
     }
 }

--- a/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
@@ -6,6 +6,20 @@ import MLXFast
 import MLXNN
 import MLXLMCommon
 
+/// Sortie d'un forward du TextModel avec les intermediaires (K/V par couche concrete).
+/// Utilise par le path MTP speculative decoding pour exposer les K/V partages
+/// du target au drafter.
+public struct LayerIntermediate {
+    public let keys: MLXArray
+    public let values: MLXArray
+    public let offset: Int
+}
+
+public struct TextForwardOutput {
+    public let hidden: MLXArray
+    public let intermediates: [LayerIntermediate?]
+}
+
 /// Linear avec scaling integre (pour per_layer_model_projection)
 class ScaledLinear: Module {
     @ModuleInfo var weight: MLXArray
@@ -149,6 +163,23 @@ public class Gemma4TextModel: Module {
         cache: [KVCache?]? = nil,
         perLayerInputs: MLXArray? = nil
     ) -> MLXArray {
+        forwardCollectingIntermediates(
+            inputs: inputs,
+            inputsEmbeds: inputsEmbeds,
+            cache: cache,
+            perLayerInputs: perLayerInputs
+        ).hidden
+    }
+
+    /// Variante de `callAsFunction` qui retourne aussi les K/V intermediaires
+    /// par couche. Utilise par le path MTP pour exposer les K/V partages au drafter.
+    /// Le `callAsFunction` standard reste inchange (delegate vers cette methode).
+    public func forwardCollectingIntermediates(
+        inputs: MLXArray? = nil,
+        inputsEmbeds: MLXArray? = nil,
+        cache: [KVCache?]? = nil,
+        perLayerInputs: MLXArray? = nil
+    ) -> TextForwardOutput {
         var h: MLXArray
         if let inputsEmbeds = inputsEmbeds {
             h = inputsEmbeds
@@ -229,6 +260,11 @@ public class Gemma4TextModel: Module {
             intermediates[i] = (kv: kv, offset: offset)
         }
 
-        return norm(h)
+        let publicIntermediates: [LayerIntermediate?] = intermediates.map { entry in
+            guard let entry = entry else { return nil }
+            return LayerIntermediate(keys: entry.kv.keys, values: entry.kv.values, offset: entry.offset)
+        }
+
+        return TextForwardOutput(hidden: norm(h), intermediates: publicIntermediates)
     }
 }

--- a/Tests/Gemma4SwiftTests/DrafterTrainingTests.swift
+++ b/Tests/Gemma4SwiftTests/DrafterTrainingTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+import MLX
+import MLXNN
+import MLXOptimizers
+@testable import Gemma4Swift
+
+@Suite("Gemma4DrafterTraining — loss + step")
+struct DrafterTrainingTests {
+
+    /// Mini drafter config + mini target config compatibles.
+    /// Target: 2 layers (1 sliding, 1 full, pas de kv-shared), hidden 32, vocab 256.
+    /// Drafter: 2 layers kv-shared-only, hidden 16, backbone 32, vocab 256.
+    let targetConfigJSON = """
+    {
+      "model_type": "gemma4_text",
+      "hidden_size": 32, "num_hidden_layers": 2, "intermediate_size": 64,
+      "num_attention_heads": 2, "num_key_value_heads": 1,
+      "head_dim": 16, "global_head_dim": 32, "rms_norm_eps": 1e-06,
+      "vocab_size": 256, "num_kv_shared_layers": 0,
+      "hidden_size_per_layer_input": 0, "vocab_size_per_layer_input": 0,
+      "sliding_window": 128, "max_position_embeddings": 1024,
+      "tie_word_embeddings": true, "enable_moe_block": false,
+      "use_double_wide_mlp": false, "attention_bias": false, "attention_k_eq_v": false,
+      "final_logit_softcapping": 0,
+      "layer_types": ["sliding_attention", "full_attention"]
+    }
+    """
+
+    let drafterConfigJSON = """
+    {
+      "model_type": "gemma4_assistant",
+      "backbone_hidden_size": 32,
+      "num_centroids": 8, "centroid_intermediate_top_k": 2,
+      "use_ordered_embeddings": true, "tie_word_embeddings": true,
+      "text_config": {
+        "model_type": "gemma4_text",
+        "hidden_size": 16, "num_hidden_layers": 2, "intermediate_size": 32,
+        "num_attention_heads": 2, "num_key_value_heads": 1,
+        "head_dim": 16, "global_head_dim": 32, "rms_norm_eps": 1e-06,
+        "vocab_size": 256, "num_kv_shared_layers": 2,
+        "hidden_size_per_layer_input": 0, "vocab_size_per_layer_input": 0,
+        "sliding_window": 128, "max_position_embeddings": 1024,
+        "tie_word_embeddings": true, "enable_moe_block": false,
+        "use_double_wide_mlp": false, "attention_bias": false, "attention_k_eq_v": false,
+        "layer_types": ["sliding_attention", "full_attention"]
+      }
+    }
+    """
+
+    @Test("drafterLoss retourne un scalaire fini non-NaN")
+    func testDrafterLossScalar() {
+        let targetCfg = try! JSONDecoder().decode(
+            Gemma4TextConfig.self, from: targetConfigJSON.data(using: .utf8)!)
+        let drafterCfg = try! JSONDecoder().decode(
+            Gemma4AssistantConfig.self, from: drafterConfigJSON.data(using: .utf8)!)
+
+        let target = Gemma4LanguageModel(targetCfg)
+        let drafter = Gemma4AssistantDraftModel(drafterCfg)
+        drafter.bind(target: target)
+
+        let B = 1, L = 8
+        let batch = MLXArray((0 ..< B * L).map { Int32($0 % 100) }).reshaped(B, L)
+
+        // last full + last sliding concrete idx
+        let layerTypes = targetCfg.resolvedLayerTypes
+        let concrete = Array(layerTypes.prefix(targetCfg.firstKvSharedLayerIdx))
+        let lastFullIdx = concrete.lastIndex(of: "full_attention") ?? 0
+        let lastSlidingIdx = concrete.lastIndex(of: "sliding_attention") ?? 0
+
+        let (loss, ntoks) = Gemma4DrafterTraining.drafterLoss(
+            drafter: drafter,
+            target: target,
+            batchTokens: batch,
+            lastFullCacheIdx: lastFullIdx,
+            lastSlidingCacheIdx: lastSlidingIdx
+        )
+        eval(loss, ntoks)
+        #expect(loss.shape == [])
+        let lossVal = loss.item(Float.self)
+        #expect(lossVal.isFinite, "loss = \(lossVal) doit etre fini")
+        #expect(lossVal > 0, "loss CE doit etre > 0 (sur init random)")
+        #expect(ntoks.item(Float.self) == Float(B * (L - 2)))  // L-2 positions valid
+    }
+
+    @Test("trainDrafter sur 2 iter ne crash pas + loss decroit (ou stable)")
+    func testTrainDrafterSmoke() throws {
+        let targetCfg = try JSONDecoder().decode(
+            Gemma4TextConfig.self, from: targetConfigJSON.data(using: .utf8)!)
+        let drafterCfg = try JSONDecoder().decode(
+            Gemma4AssistantConfig.self, from: drafterConfigJSON.data(using: .utf8)!)
+
+        let target = Gemma4LanguageModel(targetCfg)
+        let drafter = Gemma4AssistantDraftModel(drafterCfg)
+        drafter.bind(target: target)
+
+        // Mini dataset: 4 samples de 32 tokens chacun
+        let samples: [[Int]] = (0 ..< 4).map { _ in (0 ..< 32).map { _ in Int.random(in: 0 ..< 256) } }
+
+        let layerTypes = targetCfg.resolvedLayerTypes
+        let concrete = Array(layerTypes.prefix(targetCfg.firstKvSharedLayerIdx))
+        let lastFullIdx = concrete.lastIndex(of: "full_attention") ?? 0
+        let lastSlidingIdx = concrete.lastIndex(of: "sliding_attention") ?? 0
+
+        let optimizer = Adam(learningRate: 1e-3)
+
+        var config = Gemma4DrafterTraining.TrainConfig()
+        config.iterations = 2
+        config.seqLen = 16
+        config.batchSize = 1
+        config.stepsPerReport = 1
+
+        try Gemma4DrafterTraining.trainDrafter(
+            drafter: drafter, target: target,
+            tokenizedSamples: samples,
+            lastFullCacheIdx: lastFullIdx,
+            lastSlidingCacheIdx: lastSlidingIdx,
+            optimizer: optimizer,
+            config: config
+        )
+        // Si on est ici, pas de crash. Pas de save de poids (weightsURL nil).
+    }
+}

--- a/Tests/Gemma4SwiftTests/ForwardWithIntermediatesTests.swift
+++ b/Tests/Gemma4SwiftTests/ForwardWithIntermediatesTests.swift
@@ -1,0 +1,136 @@
+import Testing
+import Foundation
+import MLX
+import MLXNN
+import MLXLMCommon
+@testable import Gemma4Swift
+
+@Suite("forwardWithIntermediates / forwardCollectingIntermediates — exposition hidden + intermediates")
+struct ForwardWithIntermediatesTests {
+
+    /// Mini text config: 4 layers (pas de kv-shared), hidden 32, vocab 256.
+    /// Pas de per-layer inputs (hiddenSizePerLayerInput=0) pour simplicite.
+    let miniConfigJSON = """
+    {
+      "model_type": "gemma4_text",
+      "hidden_size": 32, "num_hidden_layers": 4, "intermediate_size": 64,
+      "num_attention_heads": 2, "num_key_value_heads": 1,
+      "head_dim": 16, "global_head_dim": 32,
+      "rms_norm_eps": 1e-06,
+      "vocab_size": 256, "num_kv_shared_layers": 0,
+      "hidden_size_per_layer_input": 0, "vocab_size_per_layer_input": 0,
+      "sliding_window": 128, "max_position_embeddings": 1024,
+      "tie_word_embeddings": true, "enable_moe_block": false,
+      "use_double_wide_mlp": false, "attention_bias": false, "attention_k_eq_v": false,
+      "final_logit_softcapping": 0,
+      "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"]
+    }
+    """
+
+    func loadConfig() -> Gemma4TextConfig {
+        let data = miniConfigJSON.data(using: .utf8)!
+        return try! JSONDecoder().decode(Gemma4TextConfig.self, from: data)
+    }
+
+    @Test("forwardCollectingIntermediates retourne hidden post-norm + intermediates [n_layers]")
+    func testTextModelForwardIntermediates() {
+        let cfg = loadConfig()
+        let model = Gemma4TextModel(cfg)
+
+        let B = 1, L = 4
+        let inputs = MLXArray((0 ..< B * L).map { Int32($0 % 100) }).reshaped(B, L)
+
+        let out = model.forwardCollectingIntermediates(inputs: inputs)
+
+        // Shapes
+        #expect(out.hidden.shape == [B, L, cfg.hiddenSize])
+        #expect(out.preNormHidden.shape == [B, L, cfg.hiddenSize])
+        #expect(out.intermediates.count == cfg.numHiddenLayers)
+
+        // Chaque intermediate doit avoir K/V shape [B, kvHeads, L, headDim]
+        // Note: full attention layer 3 utilise global_head_dim (32), sliding 0..2 utilise head_dim (16).
+        let kvHeads = cfg.numKeyValueHeads
+        let resolved = cfg.resolvedLayerTypes
+        for (i, intOpt) in out.intermediates.enumerated() {
+            guard let inter = intOpt else { Issue.record("layer \(i) intermediate is nil"); continue }
+            let expectedDim = resolved[i] == "full_attention" ? cfg.globalHeadDim : cfg.headDim
+            #expect(inter.keys.shape == [B, kvHeads, L, expectedDim],
+                    "layer \(i) (\(resolved[i])): K shape=\(inter.keys.shape)")
+            #expect(inter.values.shape == [B, kvHeads, L, expectedDim])
+        }
+
+        // No NaN
+        eval(out.hidden, out.preNormHidden)
+        #expect(!isNaN(out.hidden).any().item(Bool.self))
+        #expect(!isNaN(out.preNormHidden).any().item(Bool.self))
+    }
+
+    @Test("callAsFunction == forwardCollectingIntermediates.hidden (parite)")
+    func testCallAsFunctionParity() {
+        let cfg = loadConfig()
+        let model = Gemma4TextModel(cfg)
+
+        let B = 1, L = 4
+        let inputs = MLXArray((0 ..< B * L).map { Int32($0 % 100) }).reshaped(B, L)
+
+        let directOut = model(inputs: inputs)
+        let viaIntermediates = model.forwardCollectingIntermediates(inputs: inputs).hidden
+
+        eval(directOut, viaIntermediates)
+        let diff = abs(directOut - viaIntermediates).max().item(Float.self)
+        // Doit etre exactement egal (delegate path)
+        #expect(diff == 0, "callAsFunction et forwardCollectingIntermediates.hidden doivent etre identiques (got max diff \(diff))")
+    }
+
+    @Test("pre-norm hidden != post-norm hidden (normalize a change la valeur)")
+    func testPreNormDifferentFromPostNorm() {
+        let cfg = loadConfig()
+        let model = Gemma4TextModel(cfg)
+
+        let B = 1, L = 2
+        let inputs = MLXArray((0 ..< B * L).map { Int32($0 % 100) }).reshaped(B, L)
+
+        let out = model.forwardCollectingIntermediates(inputs: inputs)
+        eval(out.hidden, out.preNormHidden)
+
+        // norm modifie la magnitude — les deux doivent differer
+        let diff = abs(out.hidden - out.preNormHidden).max().item(Float.self)
+        #expect(diff > 1e-3, "post-norm devrait differer de pre-norm (got diff \(diff))")
+    }
+
+    @Test("LanguageModel.forwardWithIntermediates: logits + preNormHidden tous deux exposes")
+    func testLanguageModelForwardIntermediates() {
+        let cfg = loadConfig()
+        let langModel = Gemma4LanguageModel(cfg)
+
+        let B = 1, L = 3
+        let inputs = MLXArray((0 ..< B * L).map { Int32($0 % 100) }).reshaped(B, L)
+
+        let out = langModel.forwardWithIntermediates(inputs: inputs)
+        #expect(out.logits.shape == [B, L, cfg.vocabSize])
+        #expect(out.hiddenStates.shape == [B, L, cfg.hiddenSize])
+        #expect(out.preNormHiddenStates.shape == [B, L, cfg.hiddenSize])
+        #expect(out.intermediates.count == cfg.numHiddenLayers)
+
+        // logits non-NaN
+        eval(out.logits, out.preNormHiddenStates)
+        #expect(!isNaN(out.logits).any().item(Bool.self))
+        #expect(!isNaN(out.preNormHiddenStates).any().item(Bool.self))
+    }
+
+    @Test("LanguageModel.callAsFunction == forwardWithIntermediates.logits (parite)")
+    func testLanguageModelCallParity() {
+        let cfg = loadConfig()
+        let langModel = Gemma4LanguageModel(cfg)
+
+        let B = 1, L = 3
+        let inputs = MLXArray((0 ..< B * L).map { Int32($0 % 100) }).reshaped(B, L)
+
+        let directLogits = langModel(inputs: inputs)
+        let viaIntLogits = langModel.forwardWithIntermediates(inputs: inputs).logits
+
+        eval(directLogits, viaIntLogits)
+        let diff = abs(directLogits - viaIntLogits).max().item(Float.self)
+        #expect(diff == 0, "callAsFunction et forwardWithIntermediates.logits doivent etre identiques (got max diff \(diff))")
+    }
+}

--- a/Tests/Gemma4SwiftTests/Gemma4AssistantConfigTests.swift
+++ b/Tests/Gemma4SwiftTests/Gemma4AssistantConfigTests.swift
@@ -1,0 +1,221 @@
+import Testing
+import Foundation
+import MLX
+@testable import Gemma4Swift
+
+@Suite("Configuration & sanitizer Gemma 4 Assistant (MTP drafter)")
+struct Gemma4AssistantConfigTests {
+
+    /// Capture verbatim de google/gemma-4-E2B-it-assistant/config.json (mai 2026)
+    let assistantConfigJSON = """
+    {
+      "architectures": ["Gemma4AssistantForCausalLM"],
+      "audio_token_id": 258881,
+      "backbone_hidden_size": 1536,
+      "boa_token_id": 256000,
+      "boi_token_id": 255999,
+      "centroid_intermediate_top_k": 32,
+      "dtype": "bfloat16",
+      "eoa_token_id": 258883,
+      "eoi_token_id": 258882,
+      "image_token_id": 258880,
+      "model_type": "gemma4_assistant",
+      "num_centroids": 2048,
+      "text_config": {
+        "attention_bias": false,
+        "attention_dropout": 0.0,
+        "attention_k_eq_v": false,
+        "bos_token_id": 2,
+        "dtype": "bfloat16",
+        "enable_moe_block": false,
+        "eos_token_id": 1,
+        "final_logit_softcapping": null,
+        "global_head_dim": 512,
+        "head_dim": 256,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "hidden_size": 256,
+        "hidden_size_per_layer_input": 0,
+        "intermediate_size": 2048,
+        "layer_types": [
+          "sliding_attention",
+          "sliding_attention",
+          "sliding_attention",
+          "full_attention"
+        ],
+        "max_position_embeddings": 131072,
+        "model_type": "gemma4_text",
+        "num_attention_heads": 4,
+        "num_hidden_layers": 4,
+        "num_key_value_heads": 1,
+        "num_kv_shared_layers": 4,
+        "rms_norm_eps": 1e-06,
+        "rope_parameters": {
+          "full_attention": {
+            "partial_rotary_factor": 0.25,
+            "rope_theta": 1000000.0,
+            "rope_type": "proportional"
+          },
+          "sliding_attention": {
+            "rope_theta": 10000.0,
+            "rope_type": "default"
+          }
+        },
+        "sliding_window": 512,
+        "tie_word_embeddings": true,
+        "use_double_wide_mlp": false,
+        "vocab_size": 262144,
+        "vocab_size_per_layer_input": 0
+      },
+      "tie_word_embeddings": true,
+      "transformers_version": "5.7.0.dev0",
+      "use_ordered_embeddings": true
+    }
+    """
+
+    @Test("Decodage du config.json Assistant E2B")
+    func testDecodeAssistantConfig() throws {
+        let data = assistantConfigJSON.data(using: .utf8)!
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+
+        // Champs top-level MTP
+        #expect(config.modelType == "gemma4_assistant")
+        #expect(config.backboneHiddenSize == 1536)
+        #expect(config.numCentroids == 2048)
+        #expect(config.centroidIntermediateTopK == 32)
+        #expect(config.useOrderedEmbeddings == true)
+        #expect(config.tieWordEmbeddings == true)
+
+        // Tokens speciaux
+        #expect(config.imageTokenId == 258880)
+        #expect(config.audioTokenId == 258881)
+        #expect(config.boiTokenId == 255999)
+        #expect(config.eoiTokenId == 258882)
+        #expect(config.boaTokenId == 256000)
+        #expect(config.eoaTokenId == 258883)
+
+        // Inner text config — drafter 4-layer / hidden 256 / kv-shared partout
+        let t = config.textConfig
+        #expect(t.modelType == "gemma4_text")
+        #expect(t.numHiddenLayers == 4)
+        #expect(t.hiddenSize == 256)
+        #expect(t.intermediateSize == 2048)
+        #expect(t.numAttentionHeads == 4)
+        #expect(t.numKeyValueHeads == 1)
+        #expect(t.headDim == 256)
+        #expect(t.globalHeadDim == 512)
+        #expect(t.numKvSharedLayers == 4)
+        #expect(t.firstKvSharedLayerIdx == 0)  // toutes les couches sont kv-shared
+        #expect(t.vocabSize == 262144)
+        #expect(t.slidingWindow == 512)
+        #expect(t.hiddenSizePerLayerInput == 0)
+        #expect(t.vocabSizePerLayerInput == 0)
+        #expect(t.tieWordEmbeddings == true)
+        #expect(t.enableMoeBlock == false)
+        #expect(t.useDoubleWideMlp == false)
+        #expect(t.layerTypes == ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"])
+    }
+
+    @Test("RoPE parameters du drafter")
+    func testDrafterRoPE() throws {
+        let data = assistantConfigJSON.data(using: .utf8)!
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+
+        let t = config.textConfig
+        #expect(t.ropeTheta(forLayerType: "full_attention") == 1000000.0)
+        #expect(t.ropeTheta(forLayerType: "sliding_attention") == 10000.0)
+        #expect(t.ropeType(forLayerType: "full_attention") == "proportional")
+        #expect(t.ropeType(forLayerType: "sliding_attention") == "default")
+        #expect(t.fullAttentionPartialRotaryFactor == 0.25)
+    }
+
+    @Test("Resolved layer types — pattern alignement")
+    func testResolvedLayerTypes() throws {
+        let data = assistantConfigJSON.data(using: .utf8)!
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+
+        let resolved = config.textConfig.resolvedLayerTypes
+        #expect(resolved.count == 4)
+        #expect(resolved[0] == "sliding_attention")
+        #expect(resolved[3] == "full_attention")
+    }
+
+    // MARK: - Sanitizer
+
+    @Test("Sanitizer convertit token_ordering en Int32")
+    func testTokenOrderingInt32() {
+        let weights: [String: MLXArray] = [
+            "masked_embedding.token_ordering": MLXArray.zeros([2048, 128], type: Float32.self),
+            "masked_embedding.centroids.weight": MLXArray.zeros([2048, 256]),
+        ]
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: weights,
+            tieWordEmbeddings: true
+        )
+        #expect(sanitized["masked_embedding.token_ordering"] != nil)
+        #expect(sanitized["masked_embedding.token_ordering"]?.dtype == .int32)
+        #expect(sanitized["masked_embedding.centroids.weight"]?.dtype != .int32)
+    }
+
+    @Test("Sanitizer skip lm_head si tie_word_embeddings=true")
+    func testSkipLmHeadWhenTied() {
+        let weights: [String: MLXArray] = [
+            "lm_head.weight": MLXArray.zeros([262144, 256]),
+            "model.embed_tokens.weight": MLXArray.zeros([262144, 256]),
+        ]
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: weights,
+            tieWordEmbeddings: true
+        )
+        #expect(sanitized["lm_head.weight"] == nil)
+        #expect(sanitized["model.embed_tokens.weight"] != nil)
+    }
+
+    @Test("Sanitizer garde lm_head si tie_word_embeddings=false")
+    func testKeepLmHeadWhenUntied() {
+        let weights: [String: MLXArray] = [
+            "lm_head.weight": MLXArray.zeros([262144, 256]),
+        ]
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: weights,
+            tieWordEmbeddings: false
+        )
+        #expect(sanitized["lm_head.weight"] != nil)
+    }
+
+    @Test("Sanitizer skip rotary_emb")
+    func testSkipRotaryEmb() {
+        let weights: [String: MLXArray] = [
+            "model.layers.0.self_attn.rotary_emb.inv_freq": MLXArray.zeros([4]),
+            "model.layers.0.self_attn.q_proj.weight": MLXArray.zeros([4, 4]),
+        ]
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: weights,
+            tieWordEmbeddings: true
+        )
+        #expect(sanitized["model.layers.0.self_attn.rotary_emb.inv_freq"] == nil)
+        #expect(sanitized["model.layers.0.self_attn.q_proj.weight"] != nil)
+    }
+
+    @Test("Sanitizer preserve les cles standard inchangees")
+    func testStandardKeysUnchanged() {
+        let weights: [String: MLXArray] = [
+            "model.embed_tokens.weight": MLXArray.zeros([262144, 256]),
+            "model.layers.0.self_attn.q_proj.weight": MLXArray.zeros([1024, 256]),
+            "model.layers.0.mlp.gate_proj.weight": MLXArray.zeros([2048, 256]),
+            "model.norm.weight": MLXArray.zeros([256]),
+            "pre_projection.weight": MLXArray.zeros([256, 3072]),
+            "pre_projection.bias": MLXArray.zeros([256]),
+            "post_projection.weight": MLXArray.zeros([1536, 256]),
+            "post_projection.bias": MLXArray.zeros([1536]),
+            "masked_embedding.centroids.weight": MLXArray.zeros([2048, 256]),
+        ]
+        let sanitized = Gemma4AssistantWeightSanitizer.sanitize(
+            weights: weights,
+            tieWordEmbeddings: true
+        )
+        #expect(sanitized.count == weights.count)
+        for k in weights.keys {
+            #expect(sanitized[k] != nil, "cle absente: \(k)")
+        }
+    }
+}

--- a/Tests/Gemma4SwiftTests/Gemma4AssistantDrafterTests.swift
+++ b/Tests/Gemma4SwiftTests/Gemma4AssistantDrafterTests.swift
@@ -1,0 +1,177 @@
+import Testing
+import Foundation
+import MLX
+import MLXNN
+@testable import Gemma4Swift
+
+@Suite("Drafter MTP Gemma 4 Assistant — sanity forward")
+struct Gemma4AssistantDrafterTests {
+
+    // Mini config representative du E2B Assistant: 4 couches kv-shared,
+    // hidden=256, vocab=262144, num_centroids=2048, top_k=32. Reduit a un
+    // backbone fictif de 64 et vocab 256 pour tester sans allouer 256 Mo.
+    let miniConfigJSON = """
+    {
+      "model_type": "gemma4_assistant",
+      "backbone_hidden_size": 64,
+      "num_centroids": 8,
+      "centroid_intermediate_top_k": 2,
+      "use_ordered_embeddings": true,
+      "tie_word_embeddings": true,
+      "image_token_id": 258880,
+      "audio_token_id": 258881,
+      "boi_token_id": 255999,
+      "eoi_token_id": 258882,
+      "boa_token_id": 256000,
+      "eoa_token_id": 258883,
+      "text_config": {
+        "model_type": "gemma4_text",
+        "hidden_size": 32,
+        "num_hidden_layers": 2,
+        "intermediate_size": 64,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 16,
+        "global_head_dim": 32,
+        "rms_norm_eps": 1e-06,
+        "vocab_size": 256,
+        "num_kv_shared_layers": 2,
+        "hidden_size_per_layer_input": 0,
+        "vocab_size_per_layer_input": 0,
+        "sliding_window": 128,
+        "max_position_embeddings": 1024,
+        "tie_word_embeddings": true,
+        "enable_moe_block": false,
+        "use_double_wide_mlp": false,
+        "attention_bias": false,
+        "attention_k_eq_v": false,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "rope_parameters": {
+          "full_attention": {
+            "partial_rotary_factor": 0.25,
+            "rope_theta": 1000000.0,
+            "rope_type": "proportional"
+          },
+          "sliding_attention": {
+            "rope_theta": 10000.0,
+            "rope_type": "default"
+          }
+        }
+      }
+    }
+    """
+
+    @Test("Forward du drafter retourne shapes (lastHidden, logits) attendues sans NaN")
+    func testDrafterForwardShapes() throws {
+        let data = miniConfigJSON.data(using: .utf8)!
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+        let drafter = Gemma4AssistantDraftModel(config)
+
+        let B = 1
+        let L = 1
+        let kvLen = 4
+        let backbone = config.backboneHiddenSize  // 64
+        let textHidden = config.textConfig.hiddenSize  // 32
+        let vocab = config.textConfig.vocabSize  // 256
+        let numKVHeads = config.textConfig.numKeyValueHeads  // 1
+        let slidingHeadDim = config.textConfig.headDim  // 16
+        let fullHeadDim = config.textConfig.globalHeadDim  // 32
+
+        // K/V partages: shapes [B, numKVHeads, kvLen, headDim] par layer_type
+        let slidingK = MLXRandom.normal([B, numKVHeads, kvLen, slidingHeadDim])
+        let slidingV = MLXRandom.normal([B, numKVHeads, kvLen, slidingHeadDim])
+        let fullK = MLXRandom.normal([B, numKVHeads, kvLen, fullHeadDim])
+        let fullV = MLXRandom.normal([B, numKVHeads, kvLen, fullHeadDim])
+
+        let sharedKV: SharedKVStates = [
+            "sliding_attention": (keys: slidingK, values: slidingV),
+            "full_attention": (keys: fullK, values: fullV),
+        ]
+
+        // Input du drafter: concat(target_embed, target_hidden) [B, L, 2*backbone]
+        let inputs = MLXRandom.normal([B, L, 2 * backbone])
+
+        let (lastHidden, logits) = drafter(
+            inputsEmbeds: inputs,
+            sharedKVStates: sharedKV,
+            position: kvLen
+        )
+
+        // Shapes
+        #expect(lastHidden.shape == [B, L, backbone])
+        #expect(logits.shape == [B, L, vocab])
+
+        // Eval pour materialiser et controler les NaN
+        eval(lastHidden, logits)
+        let logitsHasNaN = isNaN(logits).any().item(Bool.self)
+        let hiddenHasNaN = isNaN(lastHidden).any().item(Bool.self)
+        #expect(!hiddenHasNaN, "lastHidden contient des NaN")
+        #expect(!logitsHasNaN, "logits contient des NaN")
+    }
+
+    @Test("Forward avec L>1 (verify-style batch de drafts)")
+    func testDrafterForwardMultiToken() throws {
+        let data = miniConfigJSON.data(using: .utf8)!
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+        let drafter = Gemma4AssistantDraftModel(config)
+
+        let B = 1
+        let L = 3
+        let kvLen = 4
+        let numKVHeads = config.textConfig.numKeyValueHeads
+        let slidingHeadDim = config.textConfig.headDim
+        let fullHeadDim = config.textConfig.globalHeadDim
+
+        let sharedKV: SharedKVStates = [
+            "sliding_attention": (
+                keys: MLXRandom.normal([B, numKVHeads, kvLen, slidingHeadDim]),
+                values: MLXRandom.normal([B, numKVHeads, kvLen, slidingHeadDim])
+            ),
+            "full_attention": (
+                keys: MLXRandom.normal([B, numKVHeads, kvLen, fullHeadDim]),
+                values: MLXRandom.normal([B, numKVHeads, kvLen, fullHeadDim])
+            ),
+        ]
+
+        let inputs = MLXRandom.normal([B, L, 2 * config.backboneHiddenSize])
+
+        let (lastHidden, logits) = drafter(
+            inputsEmbeds: inputs,
+            sharedKVStates: sharedKV,
+            position: kvLen
+        )
+
+        #expect(lastHidden.shape == [B, L, config.backboneHiddenSize])
+        #expect(logits.shape == [B, L, config.textConfig.vocabSize])
+
+        eval(lastHidden, logits)
+        #expect(!isNaN(logits).any().item(Bool.self))
+        #expect(!isNaN(lastHidden).any().item(Bool.self))
+    }
+
+    @Test("setSharedKV stocke etat correctement")
+    func testSetSharedKV() throws {
+        let data = miniConfigJSON.data(using: .utf8)!
+        let config = try JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+        let drafter = Gemma4AssistantDraftModel(config)
+
+        let kv = MLXRandom.normal([1, 1, 8, 16])
+        let kvDict: SharedKVStates = [
+            "sliding_attention": (keys: kv, values: kv),
+            "full_attention": (keys: kv, values: kv),
+        ]
+
+        drafter.setSharedKV(kvDict, kvOffset: 8)
+        #expect(drafter.kvOffset == 8)
+        #expect(drafter.position == 8)
+        #expect(drafter.sharedKV != nil)
+
+        drafter.setSharedKV(kvDict, kvOffset: 8, position: 5)
+        #expect(drafter.position == 5)
+
+        drafter.reset()
+        #expect(drafter.sharedKV == nil)
+        #expect(drafter.kvOffset == 0)
+        #expect(drafter.position == 0)
+    }
+}

--- a/Tests/Gemma4SwiftTests/MaskedEmbedderTests.swift
+++ b/Tests/Gemma4SwiftTests/MaskedEmbedderTests.swift
@@ -1,0 +1,115 @@
+import Testing
+import Foundation
+import MLX
+import MLXNN
+@testable import Gemma4Swift
+
+@Suite("MaskedEmbedder — sparse softmax via centroids")
+struct MaskedEmbedderTests {
+
+    /// Mini config pour le drafter — 4 layers / hidden 32 / vocab 256 / 8 centroides
+    let miniConfigJSON = """
+    {
+      "model_type": "gemma4_assistant",
+      "backbone_hidden_size": 64,
+      "num_centroids": 8,
+      "centroid_intermediate_top_k": 2,
+      "use_ordered_embeddings": true,
+      "tie_word_embeddings": true,
+      "text_config": {
+        "model_type": "gemma4_text",
+        "hidden_size": 32, "num_hidden_layers": 2, "intermediate_size": 64,
+        "num_attention_heads": 2, "num_key_value_heads": 1,
+        "head_dim": 16, "global_head_dim": 32,
+        "rms_norm_eps": 1e-06,
+        "vocab_size": 256, "num_kv_shared_layers": 2,
+        "hidden_size_per_layer_input": 0, "vocab_size_per_layer_input": 0,
+        "sliding_window": 128, "max_position_embeddings": 1024,
+        "tie_word_embeddings": true, "enable_moe_block": false,
+        "use_double_wide_mlp": false, "attention_bias": false, "attention_k_eq_v": false,
+        "layer_types": ["sliding_attention", "full_attention"]
+      }
+    }
+    """
+
+    func loadConfig() -> Gemma4AssistantConfig {
+        let data = miniConfigJSON.data(using: .utf8)!
+        return try! JSONDecoder().decode(Gemma4AssistantConfig.self, from: data)
+    }
+
+    @Test("Init shapes — centroids + token_ordering")
+    func testInitShapes() {
+        let cfg = loadConfig()
+        let me = MaskedEmbedder(cfg)
+        #expect(me.hiddenSize == 32)
+        #expect(me.vocabSize == 256)
+        #expect(me.numCentroids == 8)
+        #expect(me.topK == 2)
+        #expect(me.vocabSizePerCentroid == 256 / 8)  // = 32
+        #expect(me.tokenOrdering.shape == [256])
+        #expect(me.tokenOrdering.dtype == .int32)
+    }
+
+    @Test("Forward returns logits [B, L, vocab_size] sans NaN")
+    func testForwardShape() {
+        let cfg = loadConfig()
+        let me = MaskedEmbedder(cfg)
+
+        let B = 1, L = 3
+        let hidden = MLXRandom.normal([B, L, me.hiddenSize])
+        let lmHeadWeight = MLXRandom.normal([me.vocabSize, me.hiddenSize])
+
+        let logits = me(hidden, lmHeadWeight: lmHeadWeight)
+        #expect(logits.shape == [B, L, me.vocabSize])
+
+        eval(logits)
+        #expect(!isNaN(logits).any().item(Bool.self))
+    }
+
+    @Test("Logits non-selectionnes = mask_value (= min - 1) ; selectionnes calcules normalement")
+    func testSparseScatter() {
+        let cfg = loadConfig()
+        let me = MaskedEmbedder(cfg)
+
+        // Token ordering deterministe: cluster i contient les tokens [i*32 ..< (i+1)*32]
+        // (= la partition canonique standard)
+        let orderingFlat: [Int32] = (0 ..< 256).map { Int32($0) }
+        me.update(parameters: ModuleParameters.unflattened([
+            "token_ordering": MLXArray(orderingFlat)
+        ]))
+
+        let B = 1, L = 1
+        let hidden = MLXRandom.normal([B, L, me.hiddenSize])
+        let lmHeadWeight = MLXRandom.normal([me.vocabSize, me.hiddenSize])
+
+        let logits = me(hidden, lmHeadWeight: lmHeadWeight)
+        eval(logits)
+
+        // Avec top_k=2 clusters × 32 tokens/cluster = 64 tokens "selectionnes"
+        // Les 256-64 = 192 autres positions doivent etre toutes egales au meme mask_value
+        let logits1d = logits.reshaped(-1)
+        let minVal = logits1d.min().item(Float.self)
+
+        // Au moins (vocab - top_k * vsc) positions doivent etre au mask_value
+        let mask = logits1d .== MLXArray(minVal)
+        let nMasked = mask.sum().item(Int32.self)
+        let expectedMaskedMin = 256 - 2 * 32  // = 192
+        #expect(nMasked >= expectedMaskedMin,
+                "expected >= \(expectedMaskedMin) positions au mask_value, got \(nMasked)")
+    }
+
+    @Test("Batch + multi-position — shapes preserved")
+    func testBatchMultiPosition() {
+        let cfg = loadConfig()
+        let me = MaskedEmbedder(cfg)
+
+        let B = 2, L = 5
+        let hidden = MLXRandom.normal([B, L, me.hiddenSize])
+        let lmHeadWeight = MLXRandom.normal([me.vocabSize, me.hiddenSize])
+
+        let logits = me(hidden, lmHeadWeight: lmHeadWeight)
+        #expect(logits.shape == [B, L, me.vocabSize])
+        eval(logits)
+        #expect(!isNaN(logits).any().item(Bool.self))
+    }
+}

--- a/Tests/Gemma4SwiftTests/SpeculativeWalkTests.swift
+++ b/Tests/Gemma4SwiftTests/SpeculativeWalkTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import Gemma4Swift
+
+@Suite("Speculative walk")
+struct SpeculativeWalkTests {
+
+    @Test("Mismatch immediat: accepted=0, emit [target[0]]")
+    func testMismatchAtZero() {
+        let r = SpeculativeWalk.walk(
+            drafts: [10, 20, 30],
+            targets: [99, 50, 60, 70],
+            budget: 10
+        )
+        #expect(r.accepted == 0)
+        #expect(r.newTokens == [99])
+    }
+
+    @Test("Mismatch a position 1: accepted=1, emit [d0, target[1]]")
+    func testMismatchAtOne() {
+        let r = SpeculativeWalk.walk(
+            drafts: [10, 20, 30],
+            targets: [10, 99, 60, 70],
+            budget: 10
+        )
+        #expect(r.accepted == 1)
+        #expect(r.newTokens == [10, 99])
+    }
+
+    @Test("Tous les drafts acceptes: emit drafts + target bonus final")
+    func testAllAccepted() {
+        let r = SpeculativeWalk.walk(
+            drafts: [10, 20, 30],
+            targets: [10, 20, 30, 99],
+            budget: 10
+        )
+        #expect(r.accepted == 3)
+        #expect(r.newTokens == [10, 20, 30, 99])
+    }
+
+    @Test("Budget tronque les tokens emis")
+    func testBudgetTruncation() {
+        let r = SpeculativeWalk.walk(
+            drafts: [10, 20, 30],
+            targets: [10, 20, 30, 99],
+            budget: 2
+        )
+        #expect(r.accepted == 3)
+        #expect(r.newTokens == [10, 20])
+    }
+
+    @Test("Budget = 0: aucun token emis")
+    func testZeroBudget() {
+        let r = SpeculativeWalk.walk(
+            drafts: [10, 20],
+            targets: [99, 88, 77],
+            budget: 0
+        )
+        #expect(r.accepted == 0)
+        #expect(r.newTokens.isEmpty)
+    }
+
+    @Test("Mismatch a la derniere position")
+    func testMismatchAtLast() {
+        let r = SpeculativeWalk.walk(
+            drafts: [10, 20, 30],
+            targets: [10, 20, 99, 70],
+            budget: 10
+        )
+        #expect(r.accepted == 2)
+        #expect(r.newTokens == [10, 20, 99])
+    }
+
+    @Test("Drafts vides: emit juste target[0]")
+    func testEmptyDrafts() {
+        let r = SpeculativeWalk.walk(
+            drafts: [],
+            targets: [42],
+            budget: 10
+        )
+        #expect(r.accepted == 0)
+        #expect(r.newTokens == [42])
+    }
+
+    @Test("Equivalence avec algo Python sur cas crafted")
+    func testParityWithPython() {
+        // Reference Python: d=[1,2,3], t=[1,2,99,77]
+        //   accepted = next(i for i in range(3) if d[i] != t[i]) = 2
+        //   new_tokens = (d[:2] + [t[2]])[:budget] = [1, 2, 99]
+        let r = SpeculativeWalk.walk(
+            drafts: [1, 2, 3],
+            targets: [1, 2, 99, 77],
+            budget: 10
+        )
+        #expect(r.accepted == 2)
+        #expect(r.newTokens == [1, 2, 99])
+    }
+}


### PR DESCRIPTION
## Summary

Adds full support for Google's `gemma-4-{E2B,E4B}-it-assistant` drafter models — both inference (speculative decoding via MTP) AND fine-tuning (self-distillation against a frozen target). Port of the reference implementation from [`mlx-vlm`](https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/speculative/drafters/gemma4_assistant), extended with a training pipeline and full CLI integration.

**Status**: Feature-complete on text. **107 tests pass**, zero regression.

## ⚡ Production validation: +13pp acceptance, -12% time on toolsforge dataset

Trained the drafter for 11 min on the [toolsforge LoRA dataset](https://github.com/VincentGourbin/toolsforge-lora-dataset) (~4300 French→SQL classifier samples). Bench against the same target with LoRA applied:

| Query                     | Pretrained | Fine-tuned | Δaccept | Δtime |
|---------------------------|------------|------------|---------|-------|
| "les .log"                | 8%         | 21%        | +13pp   | -11%  |
| "fichiers contenant test" | 3%         | 23%        | +20pp   | -25%  |
| "supprime tout"           | 10%        | 22%        | +12pp   | +4%   |
| "les videos"              | 10%        | 21%        | +11pp   | -8%   |
| "trie par taille"         | 13%        | 25%        | +12pp   | -7%   |
| **average**               | **8.8%**   | **22.4%**  | +13.6pp | -12%  |

**= 2.5x relative acceptance improvement, 12% faster generation on average.** The fine-tuning pipeline delivers what the MTP infrastructure promises.

## Phases delivered

### Phase 1-2 — Drafter inference (config, sanitizer, model, MaskedEmbedder)
- `Gemma4AssistantConfig` Codable
- `Gemma4AssistantWeightSanitizer` (skip lm_head when tied, token_ordering→int32)
- `Gemma4AssistantDraftModel` with `bind(target:)`, `setSharedKV(...)`, `draftBlock(...)`, `trainForward(...)`
- `MaskedEmbedder` (sparse softmax via centroids + token_ordering)
- `SpeculativeWalk` (parity with Python `_speculative_walk`)
- 19 new unit tests

### Phase 3 — End-to-end MTP pipeline
- `Gemma4MTPPipeline` actor with `mtpStream() -> AsyncThrowingStream<String, Error>` (same contract as `ChatSession.streamResponse`) AND `mtpStreamFromTokens(tokenIds:...)` for multi-turn chat
- Prefill → draft → verify → walk → rollback (uses native `KVCache.trim()` and `RotatingKVCache.trim()`)
- Multi-EOS handling (Gemma uses `<eos>=1`, `<end_of_turn>=106`)

### Phase 4 — Multimodal + standard CLI integration
- `Gemma4MultimodalLLMModel.forwardWithIntermediates` (vision/video/audio fusion routed through the MTP path)
- `Gemma4MTPPipeline` supports BOTH `Gemma4LLMModel` and `Gemma4MultimodalLLMModel`
- **`gemma4-cli generate --draft-model <repo>`**
- **`gemma4-cli chat --draft-model <repo>`**: multi-turn chat with MTP

### Phase 5 — Drafter fine-tuning via self-distillation
- `Gemma4AssistantDraftModel.trainForward`: parallel multi-position forward with causal mask
- `Gemma4DrafterTraining.drafterLoss`: self-distillation CE loss against `argmax(target_logits)` (NOT ground truth — the drafter must mimic the target to maximize acceptance)
- `Gemma4DrafterTraining.trainDrafter`: full training loop with valueAndGrad on drafter only (target frozen via `.freeze()` + `stopGradient`)
- **Mini-batch** (`--batch-size N`) and chat-format JSONL support (`{"messages": [{role, content}]}`)
- **`gemma4-cli mtp-train`**: end-to-end fine-tuning CLI
- **`gemma4-cli mtp-generate --drafter-path ...`**: load fine-tuned drafter weights
- **`gemma4-cli mtp-generate --adapter-path ...`**: apply LoRA adapter to the target (required when bench-ing against a fine-tuned target)
- **`gemma4-cli mtp-generate --full-lm-head`**: bypass MaskedEmbedder for fine-tuned drafters

## Bugs found and fixed during investigation

1. **`Gemma4Attention` k_proj/v_proj/k_norm/v_norm** were always required, but the Assistant drafter has all layers `kv_shared_only` and the checkpoint omits these projections. Made them optional, gated by a new `kvSharedOnly` flag (default `false`, back-compat).

2. **kv-shared inference RoPE off-by-L**: when concrete layer 14 wrote to cache, kv-shared layers downstream were applying RoPE at `cache.offset` (post-write) instead of `cache.offset - L` (pre-write). Fixed.

3. **Pre-norm vs post-norm hidden**: drafter's `pre_projection` was trained against the LAST decoder layer's output BEFORE the final RMSNorm. Now exposed as `preNormHiddenStates` on `LanguageForwardOutput` and used by the MTP path.

4. **MaskedEmbedder vs training**: `MaskedEmbedder` uses `putAlong` (scatter) which MLX cannot differentiate. Training bypasses it via `embed_tokens.asLinear(h)`. New `useFullLMHead` flag bypasses it at inference too (needed for fine-tuned drafters).

## Acceptance rate parity with Python reference (pretrained drafter)

Side-by-side bench:

| Prompt        | Python  | Swift   | Δ      |
|---------------|---------|---------|--------|
| math          | 49%     | 40%     | -9%    |
| code          | 24%     | 35%     | +11%   |
| translation   | 36%     | 37%     | +1%    |
| moon          | 33%     | 30%     | -3%    |
| **average**   | **35.5%** | **35.5%** | **0%** |

The 70-90% acceptance figure floating around was generic — both Python and Swift sit at ~30-50% on real prompts with the *pretrained* Google drafter. Real performance gains come from **fine-tuning the drafter on user-specific domains** (validated above on toolsforge).

## CLI surface added

| Command | Purpose |
|---|---|
| `gemma4-cli generate --draft-model` | Standard generation with MTP speedup |
| `gemma4-cli chat --draft-model` | Multi-turn chat with MTP |
| `gemma4-cli mtp-train` | Fine-tune drafter via self-distillation |
| `gemma4-cli mtp-train --batch-size N` | Mini-batch training |
| `gemma4-cli mtp-generate --drafter-path` | Test fine-tuned drafter |
| `gemma4-cli mtp-generate --adapter-path` | Apply LoRA adapter to target |
| `gemma4-cli mtp-generate --full-lm-head` | Inference without MaskedEmbedder |
| `gemma4-cli mtp-generate --compare` | Greedy equivalence test |
| `gemma4-cli mtp-smoke` | Validate drafter weights load cleanly |
| `gemma4-cli mtp-forward` | Single-round drafter test (parity validation) |
| `gemma4-cli mtp-diag-verify` | Sequential vs parallel hidden state diff |

## End-to-end usage example

```bash
# 1. Train the drafter on your domain dataset (chat format JSONL)
gemma4-cli mtp-train \
  --target ~/Library/Caches/models/mlx-community/gemma-4-e2b-it-bf16 \
  --drafter google/gemma-4-E2B-it-assistant \
  --data my_dataset/train.jsonl \
  --output ./my_drafter \
  --iterations 2000 --seq-len 64 --batch-size 4

# 2. Generate with the fine-tuned drafter (and your target's LoRA if any)
gemma4-cli generate \
  --model-path ~/Library/Caches/models/mlx-community/gemma-4-e2b-it-bf16 \
  --draft-model google/gemma-4-E2B-it-assistant \
  --drafter-path ./my_drafter/drafter.safetensors \
  --full-lm-head \
  "Your prompt here"

# Chat mode (multi-turn) with MTP
gemma4-cli chat \
  --model-path ~/Library/Caches/models/mlx-community/gemma-4-e2b-it-bf16 \
  --draft-model google/gemma-4-E2B-it-assistant \
  --drafter-path ./my_drafter/drafter.safetensors \
  --full-lm-head
```

## Limitations / future work

- `--draft-model` flag not yet on `describe` (multimodal preprocessing pipeline). Multimodal MTP works at the pipeline level — only the CLI plumbing is missing.
- Training pipeline doesn't yet update `MaskedEmbedder.centroids` (would require working around MLX's scatter VJP limitation).
- No LoRA-style PEFT for the drafter (full-weight fine-tuning only); drafter is small enough (~78M) that full FT fits in memory easily — but checkpoints are ~156 MB each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)