### PR TITLE
feat: Gemma 4 12B Unified port + on-the-fly quantization

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -283,12 +283,22 @@ python3 /tmp/benchwork/fetch_mmlu_pro_cot.py  # produit /tmp/mmlu_pro_cot.json
 
 ### Résultats
 
-| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Référence Gemma 4 (CoT + chat template) | contributor |
-|---|---|---|---|---|
-| `12B-bf16` | TBD | TBD | 77.2% | @VincentGourbin |
-| `31B-4bit` | TBD | TBD | 85.2% | @VincentGourbin |
+| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | Référence Gemma 4 (CoT + chat template) | contributor |
+|---|---|---|---|---|---|
+| `12B-bf16` | 23.3% (7h08) | 19.5% (2h47) | +3.8 pts (dans le bruit) | 77.2% | @VincentGourbin |
+| `31B-4bit` | TBD | TBD | — | 85.2% | @VincentGourbin |
 
-Les chiffres Swift / Python sont en cours de collecte avec format raw text. L'écart aux chiffres officiels est attendu (chat template requise).
+**Note sur l'écart aux chiffres officiels** (~55 pts) : le format raw text 5-shot
+CoT sous-utilise un modèle instruction-tuned. Pour matcher 77.2% officiel, il
+faudrait :
+- Chat template Gemma 4 (`<bos><start_of_turn>user...<end_of_turn>`)
+- System prompt potentiellement spécifique
+- Prompt engineering pour la structure CoT
+
+**Note sur la perf CoT** : sur Swift, l'eval CoT 12B prend ~2.5× plus de temps
+que Python (7h08 vs 2h47). Probable cause : recréation de cache à chaque
+question + prefill 1500+ tokens sans batching. Optimisation possible : réutiliser
+le préfixe 5-shot via shared KV prefix.
 
 ---
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -231,12 +231,16 @@ PYTHONPATH=~/Library/Python/3.12/lib/python/site-packages \
 
 **Notes** :
 - E2B et E4B Python crash : bug `mlx-vlm 0.6.2` sur le KV-sharing (parameters not in model). Notre Swift port gère via `WeightSanitizer` qui strip les K/V projections des couches partagées.
-- **26B-A4B (MoE) Swift -6 pts vs Python** : divergence dans notre Router. Tentative de port verbatim de la version Python actuelle (softmax-sur-top-k, fused rms_norm) a **dégradé** l'accuracy de -3 pts au lieu d'améliorer. La cause exacte reste à investiguer — probable interaction entre :
-  - Quantization 4-bit des SwitchGLU experts (calibrée sur une distribution spécifique d'activations)
-  - Ordering numérique bf16 du router
-  - Path softmax-sur-tout-puis-renormalize vs softmax-sur-top-k (mathématiquement équivalent mais distributions différentes en bf16)
-  - SwitchGLU expert dispatching différent entre Swift MLX-LM et Python MLX-LM
-  Le code Swift actuel utilise empiriquement la meilleure variante mesurée (-6 pts), mais reste sous-optimal vs Python.
+- **26B-A4B (MoE) Swift -6 pts vs Python en 4-bit MAIS +2 pts en bf16** : la divergence est **isolée au path quantisé du SwitchGLU MLX-swift-lm**, pas dans notre Router ni dans notre archi MoE.
+
+### Sweep isolation quant vs Router/MoE Swift (26B-A4B)
+
+| Config | Swift plain | Python plain | Δ Swift-Py | Swift Pro | Python Pro | Δ Swift-Py |
+|---|---|---|---|---|---|---|
+| 26B-A4B-4bit | 57.0% | **63.0%** | **-6** ⚠ | 44.8% | 47.6% | -2.8 |
+| **26B-A4B-bf16** | **59.0%** | 57.0% | **+2** ✓ | **51.4%** | 48.6% | **+2.8** ✓ |
+
+**Verdict isolation** : sur bf16 non-quantisé, Swift donne un résultat équivalent ou meilleur que Python (+2 à +2.8 pts). Le bug -6 pts en 4-bit vient donc du dispatch quantisé de `SwitchGLU` dans `mlx-swift-lm` (probablement `quantizedSwitchLinear` ou `gather_mm` quantisé moins précis qu'en Python). À reporter en upstream.
 
 Observation : sur 12B Unified, la quantification 4-bit (n'importe quel mode)
 **dégrade significativement** la qualité MMLU (-20 à -25 pts). Le 8-bit

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -240,7 +240,9 @@ PYTHONPATH=~/Library/Python/3.12/lib/python/site-packages \
 | 26B-A4B-4bit | 57.0% | **63.0%** | **-6** ⚠ | 44.8% | 47.6% | -2.8 |
 | **26B-A4B-bf16** | **59.0%** | 57.0% | **+2** ✓ | **51.4%** | 48.6% | **+2.8** ✓ |
 
-**Verdict isolation** : sur bf16 non-quantisé, Swift donne un résultat équivalent ou meilleur que Python (+2 à +2.8 pts). Le bug -6 pts en 4-bit vient donc du dispatch quantisé de `SwitchGLU` dans `mlx-swift-lm` (probablement `quantizedSwitchLinear` ou `gather_mm` quantisé moins précis qu'en Python). À reporter en upstream.
+**Verdict isolation** : sur bf16 non-quantisé, Swift donne un résultat équivalent ou meilleur que Python (+2 à +2.8 pts). Le bug -6 pts en 4-bit vient donc du dispatch quantisé de `SwitchGLU` dans `mlx-swift-lm` (probablement `quantizedSwitchLinear` ou `gather_mm` quantisé moins précis qu'en Python).
+
+**Suivi** : voir [issue #27](https://github.com/VincentGourbin/gemma-4-swift-mlx/issues/27) pour le plan d'investigation détaillé et les hypothèses.
 
 Observation : sur 12B Unified, la quantification 4-bit (n'importe quel mode)
 **dégrade significativement** la qualité MMLU (-20 à -25 pts). Le 8-bit

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -231,7 +231,12 @@ PYTHONPATH=~/Library/Python/3.12/lib/python/site-packages \
 
 **Notes** :
 - E2B et E4B Python crash : bug `mlx-vlm 0.6.2` sur le KV-sharing (parameters not in model). Notre Swift port gère via `WeightSanitizer` qui strip les K/V projections des couches partagées.
-- 26B-A4B (MoE) Swift -6 pts vs Python → possible divergence dans notre port MoE (SwitchGLU/Experts). À investiguer.
+- **26B-A4B (MoE) Swift -6 pts vs Python** : divergence dans notre Router. Tentative de port verbatim de la version Python actuelle (softmax-sur-top-k, fused rms_norm) a **dégradé** l'accuracy de -3 pts au lieu d'améliorer. La cause exacte reste à investiguer — probable interaction entre :
+  - Quantization 4-bit des SwitchGLU experts (calibrée sur une distribution spécifique d'activations)
+  - Ordering numérique bf16 du router
+  - Path softmax-sur-tout-puis-renormalize vs softmax-sur-top-k (mathématiquement équivalent mais distributions différentes en bf16)
+  - SwitchGLU expert dispatching différent entre Swift MLX-LM et Python MLX-LM
+  Le code Swift actuel utilise empiriquement la meilleure variante mesurée (-6 pts), mais reste sous-optimal vs Python.
 
 Observation : sur 12B Unified, la quantification 4-bit (n'importe quel mode)
 **dégrade significativement** la qualité MMLU (-20 à -25 pts). Le 8-bit

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -283,10 +283,13 @@ python3 /tmp/benchwork/fetch_mmlu_pro_cot.py  # produit /tmp/mmlu_pro_cot.json
 
 ### Résultats
 
-| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | Référence Gemma 4 (CoT + chat template) | contributor |
-|---|---|---|---|---|---|
-| `12B-bf16` | 23.3% (7h08) | 19.5% (2h47) | +3.8 pts (dans le bruit) | 77.2% | @VincentGourbin |
-| `31B-4bit` | TBD | TBD | — | 85.2% | @VincentGourbin |
+| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | Référence Gemma 4 (CoT + chat template) | contributor | commit |
+|---|---|---|---|---|---|---|
+| `12B-bf16` v1 (avant fix perf) | 23.3% (7h08) | 19.5% (2h47) | +3.8 pts (dans le bruit) | 77.2% | @VincentGourbin | 08b83b6 |
+| **`12B-bf16` v2 (après fast-path)** | **23.3% (3h06)** | 19.5% (2h47) | +3.8 pts (dans le bruit) | 77.2% | @VincentGourbin | 5403548 |
+| `31B-4bit` | TBD | TBD | — | 85.2% | @VincentGourbin | — |
+
+**Score identique avant/après fix** → déterminisme greedy validé.
 
 **Note sur l'écart aux chiffres officiels** (~55 pts) : le format raw text 5-shot
 CoT sous-utilise un modèle instruction-tuned. Pour matcher 77.2% officiel, il
@@ -295,10 +298,19 @@ faudrait :
 - System prompt potentiellement spécifique
 - Prompt engineering pour la structure CoT
 
-**Note sur la perf CoT** : sur Swift, l'eval CoT 12B prend ~2.5× plus de temps
-que Python (7h08 vs 2h47). Probable cause : recréation de cache à chaque
-question + prefill 1500+ tokens sans batching. Optimisation possible : réutiliser
-le préfixe 5-shot via shared KV prefix.
+**Note sur la perf CoT — évolution** :
+- v1 (commit 08b83b6) : Swift 7h08, Python 2h47 → Swift **2.5× plus lent**
+- v2 (commit 5403548) : Swift 3h06, Python 2h47 → Swift **1.11× plus lent** (gain 2.3×)
+
+Le fix v2 introduit un fast-path `forwardWithoutIntermediates` dans
+`Gemma4TextModel.callAsFunction` qui bypass la collecte d'intermediates K/V
+pour les modèles SANS KV-sharing (12B Unified, 31B). Avant le fix, on retenait
+~150 MB de K/V refs inutilisées pendant chaque forward, ce qui ajoutait une
+pression mémoire significative pendant le prefill long (1500+ tokens du 5-shot
+prompt).
+
+Pour E2B/E4B (avec KV-sharing), le path complet `forwardCollectingIntermediates`
+reste utilisé car nécessaire à l'algorithme de partage K/V entre couches.
 
 ---
 
@@ -367,6 +379,7 @@ Sources :
 | 2026-06-06 | 79341c2 | On-the-fly quantization (`--quantize-bits N`) | -3.5× RAM, +3× throughput vs bf16 |
 | 2026-06-06 | 5fde514 | Bump mlx-swift 0.31.3 → 0.31.4 | mxfp4 fonctionnel, +6% vitesse 12B 4-bit |
 | 2026-06-07 | e2c5a99 | Fix TurboQuant viability check pour MQA | TQ désactivé proprement sur 12B/E2B, évite -19% latence accidentelle |
+| 2026-06-10 | 5403548 | Fast-path callAsFunction sans intermediates (12B/31B) | MMLU Pro CoT 12B-bf16 7h08 → 3h06 (**2.3×**), throughput pur inchangé |
 
 ---
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -218,14 +218,20 @@ PYTHONPATH=~/Library/Python/3.12/lib/python/site-packages \
 
 | Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | hardware | contributor |
 |---|---|---|---|---|---|
+| `E2B-bf16` | 47.0% | crash (KV-shared bug) | — | M4 Max 96 GB | @VincentGourbin |
+| `E4B-4bit` | 55.0% | crash (KV-shared bug) | — | M4 Max 96 GB | @VincentGourbin |
 | `12B-bf16` | 57.0% | 61.0% | -4 pts | M4 Max 96 GB | @VincentGourbin |
+| `26B-A4B-4bit` (MoE) | 57.0% | **63.0%** | **-6 pts** ⚠ | M4 Max 96 GB | @VincentGourbin |
 | **`31B-4bit`** | **66.0%** | **66.0%** | **0 (exact match)** | M4 Max 96 GB | @VincentGourbin |
 | `12B-bf16` + OTF 8-bit | 58.0% | — | — | M4 Max 96 GB | @VincentGourbin |
 | `12B-bf16` + OTF 6-bit | 50.0% | — | — | M4 Max 96 GB | @VincentGourbin |
 | `12B-bf16` + OTF 4-bit affine | 32.0% | — | — | M4 Max 96 GB | @VincentGourbin |
 | `12B-bf16` + OTF 4-bit mxfp4 | 34.0% | — | — | M4 Max 96 GB | @VincentGourbin |
 | `12B-4bit` pre-quant (mix 4/8) | 37.0% | — | — | M4 Max 96 GB | @VincentGourbin |
-| `E2B-bf16` | 36.7% (n=30) | — | — | M4 Max 96 GB | @VincentGourbin |
+
+**Notes** :
+- E2B et E4B Python crash : bug `mlx-vlm 0.6.2` sur le KV-sharing (parameters not in model). Notre Swift port gère via `WeightSanitizer` qui strip les K/V projections des couches partagées.
+- 26B-A4B (MoE) Swift -6 pts vs Python → possible divergence dans notre port MoE (SwitchGLU/Experts). À investiguer.
 
 Observation : sur 12B Unified, la quantification 4-bit (n'importe quel mode)
 **dégrade significativement** la qualité MMLU (-20 à -25 pts). Le 8-bit
@@ -254,12 +260,18 @@ python3 /tmp/benchwork/fetch_mmlu_pro.py  # produit /tmp/mmlu_pro_5shot.json
 
 ### Résultats
 
-| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | hardware | contributor |
-|---|---|---|---|---|---|
-| `12B-bf16` | 40.0% | 38.1% | +1.9 pts | M4 Max 96 GB | @VincentGourbin |
-| `31B-4bit` | 52.9% | 53.3% | -0.4 pts (1 question) | M4 Max 96 GB | @VincentGourbin |
+| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | Google ref (CoT + chat template) | Δ vs Google | hardware | contributor |
+|---|---|---|---|---|---|---|---|
+| `E2B-bf16` | 24.8% | crash | — | 60.0% | -35 pts | M4 Max 96 GB | @VincentGourbin |
+| `E4B-4bit` | 32.9% | crash | — | 69.4% | -36 pts | M4 Max 96 GB | @VincentGourbin |
+| `12B-bf16` | 40.0% | 38.1% | +1.9 pts | 77.2% | -37 pts | M4 Max 96 GB | @VincentGourbin |
+| `26B-A4B-4bit` (MoE) | 44.8% | **47.6%** | **-2.8 pts** | 82.6% | -38 pts | M4 Max 96 GB | @VincentGourbin |
+| `31B-4bit` | 52.9% | 53.3% | -0.4 pts | 85.2% | -32 pts | M4 Max 96 GB | @VincentGourbin |
 
-Δ entre Swift et Python ≤ 2 pts → **portage validé**.
+**Observations** :
+- Δ Swift ↔ Python ≤ 3 pts sur tous les modèles testables → **portage validé**.
+- Écart constant ~35 pts vs Google → c'est le **gap méthodologique** (raw text non-CoT vs chat template + CoT). Cohérent à travers les 5 modèles.
+- 26B-A4B Swift -2.8 vs Python : à investiguer côté MoE.
 
 ---
 
@@ -349,14 +361,22 @@ pour la lecture d'OCR. Sans elle, le modèle hallucine ("ASICS TRAXXON" inventé
 
 ### Chiffres officiels Gemma 4 (depuis HuggingFace model cards)
 
-| Modèle | MMLU Pro (CoT) | GPQA Diamond | AIME 2026 |
-|---|---|---|---|
-| `12B-it` | 77.2% | 78.8% | 77.5% |
-| `31B-it` | 85.2% | 84.3% | 89.2% |
+| Modèle | MMLU Pro (CoT) | GPQA Diamond | AIME 2026 | LiveCodeBench v6 | MMMLU |
+|---|---|---|---|---|---|
+| `E2B-it` | 60.0% | 43.4% | 37.5% | 44.0% | 67.4% |
+| `E4B-it` | 69.4% | 58.6% | 42.5% | 52.0% | 76.6% |
+| `12B-it` | 77.2% | 78.8% | 77.5% | 72.0% | 83.4% |
+| `26B-A4B-it` (MoE) | 82.6% | 82.3% | 88.3% | 77.1% | 86.3% |
+| `31B-it` | 85.2% | 84.3% | 89.2% | 80.0% | 88.4% |
 
 Sources :
+- https://huggingface.co/google/gemma-4-E2B-it
+- https://huggingface.co/google/gemma-4-E4B-it
 - https://huggingface.co/google/gemma-4-12B-it
+- https://huggingface.co/google/gemma-4-26b-a4b-it
 - https://huggingface.co/google/gemma-4-31B-it
+
+**Note méthodologique** : Google reporte uniquement MMLU Pro avec CoT + chat template. Notre eval-mmlu utilise un format raw text 5-shot logit-based — donc Δ ~35 pts constant attendu vs Google. La comparaison Swift ↔ Python valide le portage à epsilon près ; la comparaison vs Google valide le tier du modèle (E2B < E4B < 12B < 26B-MoE < 31B est préservé).
 
 ### Hardware de référence M4 Max
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,373 @@
+# Gemma 4 — Benchmarks collaboratifs
+
+Ce fichier rassemble tous les benchmarks reproductibles pour la famille Gemma 4
+(E2B, E4B, 12B Unified, 26B-A4B, 31B) à travers les différents frameworks
+disponibles. Il est conçu pour être **collaboratif** : chaque ligne de résultat
+référence le framework, la version, le matériel et la commande exacte utilisée.
+
+L'objectif est triple :
+1. Documenter la baseline de notre framework (Gemma 4 Swift MLX)
+2. Permettre la comparaison avec d'autres ports (mlx-vlm Python, futurs ports CUDA, etc.)
+3. Suivre l'évolution des perfs au fil des versions et des optimisations
+
+---
+
+## Comment lire ce fichier
+
+Chaque catégorie de benchmark a :
+- **Standard setup** : prompt, paramètres exacts, hardware de référence
+- **Commande Swift** : ligne CLI pour reproduire avec ce repo
+- **Commande Python** (quand applicable) : référence mlx-vlm
+- **Tableau de résultats** : framework × version × hardware × score × contributeur
+
+Le hardware de référence est **Apple M4 Max 96 GB RAM** (les contributeurs avec
+d'autres machines sont encouragés à ajouter leurs colonnes).
+
+---
+
+## Comment contribuer un résultat
+
+1. Reproduis le bench exact (commande dans la section concernée)
+2. Ouvre une PR avec :
+   - Une ligne de tableau ajoutée dans la bonne section
+   - Format de la ligne : `| framework version | hardware | métrique | score | contributeur | date | commit |`
+   - Le contributeur est ton handle GitHub
+   - Le commit est le SHA court de ton repo (ou "N/A" pour un framework externe stable)
+3. Si tu portes sur un nouveau framework (CUDA, ROCm, etc.), ajoute une section
+   au-dessus du tableau qui décrit ton setup
+
+Pour un nouveau benchmark (autre tâche, autre dataset), ouvre une PR qui :
+- Ajoute une section sous "Benchmarks"
+- Définit le standard setup
+- Ajoute les commandes de reproduction
+- Soumet au moins UN résultat de référence
+
+---
+
+## Frameworks référencés
+
+| ID | Framework | Repo |
+|---|---|---|
+| `swift-mlx` | Gemma 4 Swift MLX (ce repo) | https://github.com/VincentGourbin/gemma-4-swift-mlx |
+| `mlx-vlm-py` | mlx-vlm Python | https://github.com/Blaizzy/mlx-vlm |
+| `mlx-lm-py` | mlx-lm Python (text-only) | https://github.com/ml-explore/mlx-lm |
+| `transformers-cuda` | HuggingFace transformers + CUDA | https://github.com/huggingface/transformers |
+
+---
+
+## Modèles standard utilisés
+
+| Alias | HF ID | Taille | Quantization |
+|---|---|---|---|
+| `E2B-bf16` | `mlx-community/gemma-4-e2b-it-bf16` | ~9 GB | bf16 |
+| `12B-bf16` | `mlx-community/gemma-4-12B-it-bf16` | ~22 GB | bf16 |
+| `12B-4bit` | `mlx-community/gemma-4-12B-it-4bit` | ~10 GB | mix 4-bit attn + 8-bit MLP |
+| `31B-4bit` | `mlx-community/gemma-4-31b-it-4bit` | ~17 GB | 4-bit affine g=64 |
+
+Les variantes 6-bit / 8-bit / bf16 sont disponibles symétriquement chez mlx-community.
+
+---
+
+# Benchmarks
+
+## 1. Inference throughput (text-only)
+
+### Standard setup
+
+Prompt : `"Explain the theory of relativity, including special and general relativity, in detail with mathematical formulations."` (45 tokens)
+Génération : 100 tokens, temperature 0.0, greedy
+KV cache : bf16 (sauf si KV TurboQuant spécifié)
+
+### Commandes
+
+**swift-mlx** :
+```bash
+./.build/xcode/Build/Products/Release/gemma4-cli profile run \
+  --model-path <MODEL_PATH> \
+  --prompt "Explain the theory of relativity, including special and general relativity, in detail with mathematical formulations." \
+  --max-tokens 100 --temperature 0.0 --no-chrome-trace \
+  [--quantize-bits N --quantize-mode {affine|mxfp4} --quantize-group-size G]
+```
+
+**mlx-vlm-py** : utiliser `mlx_vlm.generate` avec les mêmes paramètres (voir `BENCHMARKS_python_scripts/` pour le script de référence).
+
+### Résultats — 12B (M4 Max)
+
+| Config | t/s | RAM MLX | framework version | hardware | contributor | date | commit |
+|---|---|---|---|---|---|---|---|
+| `12B-bf16` natif | 11.3 | 22.8 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `12B-bf16` + OTF 8-bit affine g=64 | 19.7 | 12.2 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `12B-bf16` + OTF 6-bit affine g=64 | 24.3 | 9.4 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `12B-bf16` + OTF 4-bit affine g=64 | 33.4 | 6.5 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `12B-bf16` + OTF 4-bit affine g=128 | 33.0 | 6.2 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| **`12B-bf16` + OTF 4-bit mxfp4 g=32** | **34.7** | **6.2 GB** | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `12B-4bit` pre-quant (mix 4/8) | 22.5 | 10.6 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `12B-4bit` pre-quant | 21.5 | 10.6 GB | mlx-vlm-py@0.6.2 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | N/A |
+
+### Résultats — E2B (M4 Max)
+
+| Config | t/s | RAM MLX | framework version | hardware | contributor | date | commit |
+|---|---|---|---|---|---|---|---|
+| `E2B-bf16` natif | 46.5 | 8.9 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `E2B-bf16` + OTF 8-bit | 74.6 | 4.7 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `E2B-bf16` + OTF 6-bit | 86.2 | 3.6 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| `E2B-bf16` + OTF 4-bit affine | 105.3 | 2.5 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+| **`E2B-bf16` + OTF 4-bit mxfp4** | **108** | **2.4 GB** | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin | 2026-06-06 | e2c5a99 |
+
+---
+
+## 2. Prefill scaling (decode rate vs context length)
+
+### Standard setup
+
+Modèle : `12B-bf16` + OTF 4-bit mxfp4 g=32
+Génération : 30 tokens en greedy après le prompt
+Mesure : moyenne `ms/token` sur la phase de génération (post-prefill)
+
+### Résultats — 12B (M4 Max)
+
+| Prompt size | ms/token | t/s | RAM | framework version | hardware | contributor |
+|---|---|---|---|---|---|---|
+| 28 tokens | 30.5 | 32.8 | 6.5 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin |
+| 127 tokens | 30.4 | 32.9 | 6.6 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin |
+| 1226 tokens | 39.2 | 25.5 | 7.4 GB | swift-mlx@e2c5a99 | M4 Max 96 GB | @VincentGourbin |
+
+Observation : decode reste stable jusqu'à ~150 tokens de contexte, puis chute
+progressive au-delà (KV cache à parcourir grossit).
+
+---
+
+## 3. TurboQuant KV cache validation
+
+### Standard setup
+
+Modèle : `12B-bf16` ou `31B-4bit`
+Test : sweep prompt size 256 → 8192 tokens, generation 30 tokens, temp 0.0
+Configs comparées : KV bf16 vs KV TQ4 (4-bit affine TurboQuant)
+
+### Commande Swift
+
+```bash
+./.build/xcode/Build/Products/Release/gemma4-cli profile run \
+  --model-path <MODEL_PATH> --prompt "<LONG_PROMPT>" \
+  --max-tokens 30 --temperature 0.0 --no-chrome-trace \
+  --kv-bits 4   # active TurboQuant sur full_attention layers
+```
+
+### Comportement attendu du check viability
+
+| Modèle | KV heads sur full_attn | Verdict check | Raison |
+|---|---|---|---|
+| `E2B` | 1 (MQA) | Désactivé silencieusement | gain 64 MB < 250 MB overhead |
+| `12B Unified` | 1 (MQA full attn) | Désactivé silencieusement | gain 171 MB < 250 MB overhead |
+| `31B` | 4 (GQA full attn) | Activé | gain 950 MB > 250 MB overhead |
+| `26B-A4B` | 4 (GQA full attn) | Activé (à valider) | TBD |
+
+Le check est exposé en static : `Gemma4LanguageModel.turboQuantViability(config:bits:)`.
+
+### Résultats — 31B (TQ activé)
+
+| Prompt | KV bf16 ms/t | KV TQ4 ms/t | Δ time | RAM bf16 | RAM TQ4 | Δ RAM | framework | hardware |
+|---|---|---|---|---|---|---|---|---|
+| 421 | 75.3 | 85.3 | +13% | 17.3 GB | 17.2 GB | -24 MB | swift-mlx@e2c5a99 | M4 Max 96 GB |
+| 1573 | 78.5 | 88.6 | +13% | 18.6 GB | 18.5 GB | -107 MB | swift-mlx@e2c5a99 | M4 Max 96 GB |
+| 6181 | 101.6 | 132.4 | +30% | 24.9 GB | 24.5 GB | -375 MB | swift-mlx@e2c5a99 | M4 Max 96 GB |
+| 12325 | 162.0 | 164.8 | +2% | 33.2 GB | 32.5 GB | **-735 MB** | swift-mlx@e2c5a99 | M4 Max 96 GB |
+
+Observation : TQ a un coût perf court contexte (+13-30%) qui s'amortit à long
+contexte. Le gain RAM scale linéairement (~30 MB par K tokens). Pertinent pour
+machines RAM-limitées sur contextes ≥ 8K.
+
+### Résultats — 12B (TQ auto-désactivé)
+
+| Prompt | bf16-kv | TQ4-kv (auto-désactivé) | Agreement | framework |
+|---|---|---|---|---|
+| 256 → 8192 (4 ctx) | identique | identique | 100% | swift-mlx@e2c5a99 |
+
+Le check refuse silencieusement → `--kv-bits 4` fallback vers KV bf16 standard.
+
+---
+
+## 4. MMLU plain 5-shot (logit-based)
+
+### Standard setup
+
+Dataset : `cais/mmlu`, 10 sujets stratifiés × 10 questions test = 100 questions
+5-shot examples : dev split de `cais/mmlu` (5 par sujet)
+Méthodologie : argmax sur logits des tokens " A", " B", " C", " D" après "Answer:"
+
+### Commande Swift
+
+```bash
+# Fetch dataset
+python3 /tmp/benchwork/fetch_mmlu.py  # produit /tmp/mmlu_5shot.json
+
+./.build/xcode/Build/Products/Release/gemma4-cli eval-mmlu \
+  --model-path <MODEL_PATH> --dataset /tmp/mmlu_5shot.json \
+  [--kv-bits 4] [--quantize-bits N --quantize-mode {affine|mxfp4}]
+```
+
+### Commande Python (référence)
+
+```bash
+PYTHONPATH=~/Library/Python/3.12/lib/python/site-packages \
+  python3 /tmp/benchwork/mmlu_python.py --model-path <MODEL_PATH>
+```
+
+### Résultats
+
+| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | hardware | contributor |
+|---|---|---|---|---|---|
+| `12B-bf16` | 57.0% | 61.0% | -4 pts | M4 Max 96 GB | @VincentGourbin |
+| **`31B-4bit`** | **66.0%** | **66.0%** | **0 (exact match)** | M4 Max 96 GB | @VincentGourbin |
+| `12B-bf16` + OTF 8-bit | 58.0% | — | — | M4 Max 96 GB | @VincentGourbin |
+| `12B-bf16` + OTF 6-bit | 50.0% | — | — | M4 Max 96 GB | @VincentGourbin |
+| `12B-bf16` + OTF 4-bit affine | 32.0% | — | — | M4 Max 96 GB | @VincentGourbin |
+| `12B-bf16` + OTF 4-bit mxfp4 | 34.0% | — | — | M4 Max 96 GB | @VincentGourbin |
+| `12B-4bit` pre-quant (mix 4/8) | 37.0% | — | — | M4 Max 96 GB | @VincentGourbin |
+| `E2B-bf16` | 36.7% (n=30) | — | — | M4 Max 96 GB | @VincentGourbin |
+
+Observation : sur 12B Unified, la quantification 4-bit (n'importe quel mode)
+**dégrade significativement** la qualité MMLU (-20 à -25 pts). Le 8-bit
+préserve la qualité, le 6-bit perd 7 pts (acceptable). Le 31B est beaucoup plus
+robuste à la quant 4-bit grâce à sa GQA(4) et ses 60 layers.
+
+---
+
+## 5. MMLU Pro 5-shot (logit-based, non-CoT)
+
+### Standard setup
+
+Dataset : `TIGER-Lab/MMLU-Pro`, 14 catégories × 15 questions = 210 questions
+5-shot examples : split `validation` (5 par catégorie)
+Méthodologie : argmax sur logits des tokens " A".." J" après "Answer:"
+**Note** : Sans CoT → score absolu plus bas que les chiffres officiels Gemma 4 (77.2% / 85.2% sont avec CoT)
+
+### Commande Swift
+
+```bash
+python3 /tmp/benchwork/fetch_mmlu_pro.py  # produit /tmp/mmlu_pro_5shot.json
+
+./.build/xcode/Build/Products/Release/gemma4-cli eval-mmlu \
+  --model-path <MODEL_PATH> --dataset /tmp/mmlu_pro_5shot.json
+```
+
+### Résultats
+
+| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Δ Swift-Python | hardware | contributor |
+|---|---|---|---|---|---|
+| `12B-bf16` | 40.0% | 38.1% | +1.9 pts | M4 Max 96 GB | @VincentGourbin |
+| `31B-4bit` | 52.9% | 53.3% | -0.4 pts (1 question) | M4 Max 96 GB | @VincentGourbin |
+
+Δ entre Swift et Python ≤ 2 pts → **portage validé**.
+
+---
+
+## 6. MMLU Pro 5-shot CoT (Chain-of-Thought)
+
+### Standard setup
+
+Dataset : `TIGER-Lab/MMLU-Pro` avec `cot_content` (raisonnement pré-rédigé) dans les 5-shot
+Génération : greedy, max_tokens 512, parse "The answer is (X)" / "(X)"
+**Note** : Pour matcher les 77.2% / 85.2% officiels, il faut probablement utiliser la chat template Gemma 4 et un prompt engineering plus poussé. Notre format raw text donne des scores plus bas mais permet la comparaison Swift ↔ Python.
+
+### Commande Swift
+
+```bash
+python3 /tmp/benchwork/fetch_mmlu_pro_cot.py  # produit /tmp/mmlu_pro_cot.json
+
+./.build/xcode/Build/Products/Release/gemma4-cli eval-mmlu \
+  --model-path <MODEL_PATH> --dataset /tmp/mmlu_pro_cot.json \
+  --cot [--cot-max-tokens 512]
+```
+
+### Résultats
+
+| Modèle | swift-mlx | mlx-vlm-py 0.6.2 | Référence Gemma 4 (CoT + chat template) | contributor |
+|---|---|---|---|---|
+| `12B-bf16` | TBD | TBD | 77.2% | @VincentGourbin |
+| `31B-4bit` | TBD | TBD | 85.2% | @VincentGourbin |
+
+Les chiffres Swift / Python sont en cours de collecte avec format raw text. L'écart aux chiffres officiels est attendu (chat template requise).
+
+---
+
+## 7. Visualisation multimodale (qualitative)
+
+### Standard setup
+
+Test : description d'image avec prompt "Describe what's in the image in 2 sentences."
+Image de référence : voir `tests/fixtures/runner.jpg` (à ajouter)
+Modèle : `12B-bf16` + OTF 4-bit mxfp4
+
+### Commande Swift
+
+```bash
+./.build/xcode/Build/Products/Release/gemma4-cli describe \
+  --model-path <MODEL_PATH> --image <IMAGE_PATH> \
+  --prompt "Describe what's in the image in 2 sentences." \
+  --max-tokens 100 --temperature 0.0 \
+  --quantize-bits 4 --quantize-mode mxfp4
+```
+
+### Qualité (subjective, à valider sur dataset MM-Vet ou similaire)
+
+Sur l'image de coureurs au marathon, le 12B Unified lit correctement :
+- Textes sur les vêtements : "F&M TRACK CLUB" ✓
+- Textes sur banderoles : "START", "SPAR" ✓
+- Textes sur dossards : "CAELIN", "WELMA" ✓
+
+→ La bidirectional attention sur tokens vision (commit 79341c2) est critique
+pour la lecture d'OCR. Sans elle, le modèle hallucine ("ASICS TRAXXON" inventé,
+"RUNNING FOR LIFE" inventé).
+
+---
+
+## Références externes
+
+### Chiffres officiels Gemma 4 (depuis HuggingFace model cards)
+
+| Modèle | MMLU Pro (CoT) | GPQA Diamond | AIME 2026 |
+|---|---|---|---|
+| `12B-it` | 77.2% | 78.8% | 77.5% |
+| `31B-it` | 85.2% | 84.3% | 89.2% |
+
+Sources :
+- https://huggingface.co/google/gemma-4-12B-it
+- https://huggingface.co/google/gemma-4-31B-it
+
+### Hardware de référence M4 Max
+
+- Apple M4 Max
+- 96 GB RAM unified
+- 546 GB/s memory bandwidth nominale
+- macOS 14+
+- Swift 6.0
+- mlx-swift 0.31.4
+- mlx-vlm Python 0.6.2
+
+---
+
+## Historique des optimisations
+
+| Date | Commit | Optimisation | Impact mesuré |
+|---|---|---|---|
+| 2026-06-06 | 79341c2 | Port Gemma 4 12B Unified + bidirectional attention | qualité OCR multimodal: hallucinations → lectures exactes |
+| 2026-06-06 | 79341c2 | ProportionalRoPE simplifiée (inf-padded freqs) | +2-3% throughput 12B |
+| 2026-06-06 | 79341c2 | On-the-fly quantization (`--quantize-bits N`) | -3.5× RAM, +3× throughput vs bf16 |
+| 2026-06-06 | 5fde514 | Bump mlx-swift 0.31.3 → 0.31.4 | mxfp4 fonctionnel, +6% vitesse 12B 4-bit |
+| 2026-06-07 | e2c5a99 | Fix TurboQuant viability check pour MQA | TQ désactivé proprement sur 12B/E2B, évite -19% latence accidentelle |
+
+---
+
+## Annexe : scripts de fetch des datasets
+
+Tous les scripts vivent dans `BENCHMARKS_python_scripts/` (à ajouter au repo).
+
+| Script | Sortie | Source HF |
+|---|---|---|
+| `fetch_mmlu.py` | `/tmp/mmlu_5shot.json` | `cais/mmlu` (10 subjects × 10 q) |
+| `fetch_mmlu_pro.py` | `/tmp/mmlu_pro_5shot.json` | `TIGER-Lab/MMLU-Pro` (14 cats × 15 q) |
+| `fetch_mmlu_pro_cot.py` | `/tmp/mmlu_pro_cot.json` | `TIGER-Lab/MMLU-Pro` avec `cot_content` |
+| `mmlu_python.py` | run éval Python mlx-vlm | logit-based |
+| `mmlu_pro_cot_py.py` | run éval Python CoT | génération + parse |

--- a/BENCHMARKS_python_scripts/fetch_mmlu.py
+++ b/BENCHMARKS_python_scripts/fetch_mmlu.py
@@ -1,0 +1,28 @@
+"""Telecharge un subset de MMLU pour eval Swift. Stratifie sur ~10 sujets."""
+import json, random, sys
+from datasets import load_dataset
+
+random.seed(42)
+N_PER_SUBJECT = 10
+SUBJECTS = [
+    "abstract_algebra", "anatomy", "astronomy", "business_ethics",
+    "college_biology", "college_chemistry", "elementary_mathematics",
+    "global_facts", "high_school_geography", "world_religions"
+]
+
+out = []
+for subj in SUBJECTS:
+    ds = load_dataset("cais/mmlu", subj, split="test")
+    indices = random.sample(range(len(ds)), min(N_PER_SUBJECT, len(ds)))
+    for i in indices:
+        item = ds[i]
+        out.append({
+            "subject": subj,
+            "question": item["question"],
+            "choices": item["choices"],
+            "answer": item["answer"],  # 0..3
+        })
+
+with open("mmlu_mini.json", "w") as f:
+    json.dump(out, f, indent=2)
+print(f"Sauve {len(out)} questions dans mmlu_mini.json")

--- a/BENCHMARKS_python_scripts/fetch_mmlu_5shot.py
+++ b/BENCHMARKS_python_scripts/fetch_mmlu_5shot.py
@@ -1,0 +1,31 @@
+"""Telecharge MMLU avec dev examples (pour 5-shot)."""
+import json, random
+from datasets import load_dataset
+
+random.seed(42)
+N_PER_SUBJECT = 10
+SUBJECTS = [
+    "abstract_algebra", "anatomy", "astronomy", "business_ethics",
+    "college_biology", "college_chemistry", "elementary_mathematics",
+    "global_facts", "high_school_geography", "world_religions"
+]
+
+out = {"subjects": {}, "questions": []}
+for subj in SUBJECTS:
+    dev = load_dataset("cais/mmlu", subj, split="dev")  # 5 examples par sujet
+    test = load_dataset("cais/mmlu", subj, split="test")
+    dev_items = [dict(q=dev[i]["question"], c=dev[i]["choices"], a=dev[i]["answer"]) for i in range(len(dev))]
+    out["subjects"][subj] = {"dev": dev_items}
+    indices = random.sample(range(len(test)), min(N_PER_SUBJECT, len(test)))
+    for i in indices:
+        item = test[i]
+        out["questions"].append({
+            "subject": subj,
+            "question": item["question"],
+            "choices": item["choices"],
+            "answer": item["answer"],
+        })
+
+with open("mmlu_5shot.json", "w") as f:
+    json.dump(out, f, indent=2)
+print(f"Sauve {len(out['questions'])} test questions + {len(SUBJECTS)} subjects (5 dev each)")

--- a/BENCHMARKS_python_scripts/fetch_mmlu_pro.py
+++ b/BENCHMARKS_python_scripts/fetch_mmlu_pro.py
@@ -1,0 +1,40 @@
+import json, random
+from datasets import load_dataset
+
+random.seed(42)
+N_PER_CAT = 15  # 14 categories * 15 = 210 test questions
+
+val = load_dataset("TIGER-Lab/MMLU-Pro", split="validation")
+test = load_dataset("TIGER-Lab/MMLU-Pro", split="test")
+
+# Index val par category pour les dev examples (5-shot)
+val_by_cat = {}
+for v in val:
+    val_by_cat.setdefault(v['category'], []).append({
+        "q": v['question'], "c": v['options'], "a": v['answer_index']
+    })
+print(f"Val: {len(val)} examples, {len(val_by_cat)} categories")
+for cat, items in val_by_cat.items():
+    print(f"  {cat}: {len(items)} dev examples")
+
+# Strat sampling test set
+by_cat = {}
+for i, t in enumerate(test):
+    by_cat.setdefault(t['category'], []).append(i)
+questions = []
+for cat, idxs in by_cat.items():
+    sample = random.sample(idxs, min(N_PER_CAT, len(idxs)))
+    for i in sample:
+        t = test[i]
+        questions.append({
+            "subject": t['category'],
+            "question": t['question'],
+            "choices": t['options'],
+            "answer": t['answer_index'],
+        })
+
+data = {"subjects": {cat: {"dev": items} for cat, items in val_by_cat.items()},
+        "questions": questions}
+with open("mmlu_pro_5shot.json", "w") as f:
+    json.dump(data, f, indent=2)
+print(f"Sauve {len(questions)} test questions")

--- a/BENCHMARKS_python_scripts/fetch_mmlu_pro_cot.py
+++ b/BENCHMARKS_python_scripts/fetch_mmlu_pro_cot.py
@@ -1,0 +1,31 @@
+import json, random
+from datasets import load_dataset
+random.seed(42)
+N_PER_CAT = 15
+val = load_dataset("TIGER-Lab/MMLU-Pro", split="validation")
+test = load_dataset("TIGER-Lab/MMLU-Pro", split="test")
+val_by_cat = {}
+for v in val:
+    val_by_cat.setdefault(v['category'], []).append({
+        "q": v['question'], "c": v['options'], "a": v['answer_index'],
+        "cot": v['cot_content']
+    })
+by_cat = {}
+for i, t in enumerate(test):
+    by_cat.setdefault(t['category'], []).append(i)
+questions = []
+for cat, idxs in by_cat.items():
+    sample = random.sample(idxs, min(N_PER_CAT, len(idxs)))
+    for i in sample:
+        t = test[i]
+        questions.append({
+            "subject": t['category'],
+            "question": t['question'],
+            "choices": t['options'],
+            "answer": t['answer_index'],
+        })
+data = {"subjects": {cat: {"dev": items} for cat, items in val_by_cat.items()},
+        "questions": questions}
+with open("mmlu_pro_cot.json", "w") as f:
+    json.dump(data, f, indent=2)
+print(f"Sauve {len(questions)} test questions, {len(data['subjects'])} categories (avec cot_content)")

--- a/BENCHMARKS_python_scripts/mmlu_pro_cot_py.py
+++ b/BENCHMARKS_python_scripts/mmlu_pro_cot_py.py
@@ -1,0 +1,94 @@
+"""MMLU Pro 5-shot CoT eval (cache fix)."""
+import json, time, argparse, re
+import mlx.core as mx
+from mlx_vlm import load
+
+LETTERS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+def build_prefix(subj, dev_items):
+    p = f"The following are multiple choice questions (with answers) about {subj.replace('_', ' ')}.\n\n"
+    for d in dev_items:
+        p += f"{d['q']}\n"
+        for i, c in enumerate(d['c'][:len(LETTERS)]):
+            p += f"{LETTERS[i]}. {c}\n"
+        cot = d.get('cot') or ''
+        if cot:
+            p += f"{cot}\n\n"
+        else:
+            p += f"Answer: {LETTERS[d['a']]}\n\n"
+    return p
+
+def parse_letter(text, n):
+    valid = LETTERS[:n]
+    low = text.lower()
+    for m in ["answer is (", "answer is *", "answer is **", "answer is "]:
+        i = low.find(m)
+        if i >= 0:
+            tail = text[i + len(m):i + len(m) + 5]
+            for ch in tail:
+                if ch in valid: return valid.index(ch)
+    matches = re.findall(r"\(([A-J])\)", text)
+    if matches:
+        for ch in reversed(matches):
+            if ch in valid: return valid.index(ch)
+    return -1
+
+def predict_cot(lm, tokenizer, prompt, n_choices, max_tokens):
+    tokens = tokenizer.encode(prompt)
+    input_ids = mx.array(tokens).reshape(1, -1)
+    cache = lm.make_cache()
+    out = lm(input_ids, cache=cache)
+    logits = out.logits if hasattr(out, 'logits') else out
+    nxt = int(mx.argmax(logits[0, -1], axis=-1).item())
+    gen = [nxt]
+    for _ in range(max_tokens - 1):
+        if nxt in (1, 106): break
+        out = lm(mx.array([nxt]).reshape(1, 1), cache=cache)
+        logits = out.logits if hasattr(out, 'logits') else out
+        nxt = int(mx.argmax(logits[0, 0], axis=-1).item())
+        gen.append(nxt)
+        if len(gen) % 32 == 0:
+            if "the answer is" in tokenizer.decode(gen).lower():
+                break
+    return parse_letter(tokenizer.decode(gen), n_choices)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--dataset", default="/tmp/mmlu_pro_cot.json")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--max-tokens", type=int, default=512)
+    args = parser.parse_args()
+
+    with open(args.dataset) as f:
+        ds = json.load(f)
+    questions = ds["questions"]
+    if args.limit: questions = questions[:args.limit]
+
+    print(f"Loading {args.model_path}...")
+    t0 = time.perf_counter()
+    model, processor = load(args.model_path)
+    print(f"Loaded in {time.perf_counter()-t0:.1f}s")
+    tokenizer = processor.tokenizer if hasattr(processor, 'tokenizer') else processor
+    lm = model.language_model
+
+    prefixes = {s: build_prefix(s, info["dev"]) for s, info in ds["subjects"].items()}
+    correct = 0
+    t_start = time.perf_counter()
+    for idx, item in enumerate(questions):
+        prefix = prefixes.get(item["subject"], "")
+        prompt = prefix + item["question"] + "\n"
+        for i, c in enumerate(item["choices"][:len(LETTERS)]):
+            prompt += f"{LETTERS[i]}. {c}\n"
+        prompt += "A: Let's think step by step."
+        n = min(len(item["choices"]), len(LETTERS))
+        pred = predict_cot(lm, tokenizer, prompt, n, args.max_tokens)
+        if pred == item["answer"]: correct += 1
+        if (idx + 1) % 10 == 0:
+            elapsed = time.perf_counter() - t_start
+            eta = elapsed / (idx + 1) * (len(questions) - idx - 1)
+            print(f"[{idx+1}/{len(questions)}] {correct}/{idx+1} = {correct/(idx+1)*100:.1f}% | {elapsed:.0f}s, ETA {eta:.0f}s")
+    print(f"\n=== Python CoT: {correct}/{len(questions)} = {correct/len(questions)*100:.1f}% ===")
+
+if __name__ == "__main__":
+    main()

--- a/BENCHMARKS_python_scripts/mmlu_python.py
+++ b/BENCHMARKS_python_scripts/mmlu_python.py
@@ -1,0 +1,72 @@
+"""MMLU 5-shot eval cote Python mlx_vlm (supporte 4-10 choix A-J)."""
+import json, sys, time, argparse
+import mlx.core as mx
+from mlx_vlm import load
+
+LETTERS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+def build_prefix(subj, dev_items):
+    p = f"The following are multiple choice questions (with answers) about {subj.replace('_', ' ')}.\n\n"
+    for d in dev_items:
+        p += f"{d['q']}\n"
+        for i, c in enumerate(d['c'][:len(LETTERS)]):
+            p += f"{LETTERS[i]}. {c}\n"
+        p += f"Answer: {LETTERS[d['a']]}\n\n"
+    return p
+
+def predict(model, tokenizer, prompt, candidate_tokens):
+    tokens = tokenizer.encode(prompt)
+    input_ids = mx.array(tokens).reshape(1, -1)
+    out = model.language_model(input_ids) if hasattr(model, 'language_model') else model(input_ids)
+    out = out.logits if hasattr(out, 'logits') else out
+    last = out[0, -1]
+    best_idx, best_logit = 0, -1e9
+    for i, tok in enumerate(candidate_tokens):
+        l = float(last[tok].item())
+        if l > best_logit: best_idx, best_logit = i, l
+    return best_idx
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--dataset", default="/tmp/mmlu_pro_5shot.json")
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args()
+
+    with open(args.dataset) as f:
+        ds = json.load(f)
+    questions = ds["questions"]
+    if args.limit: questions = questions[:args.limit]
+
+    print(f"Loading {args.model_path}...")
+    t0 = time.perf_counter()
+    model, processor = load(args.model_path)
+    print(f"Loaded in {time.perf_counter()-t0:.1f}s")
+
+    tokenizer = processor.tokenizer if hasattr(processor, 'tokenizer') else processor
+
+    # Token IDs " A" ... " J"
+    letter_tokens = [tokenizer.encode(f" {l}")[-1] for l in LETTERS]
+    print(f"Tokens: " + " ".join(f"{LETTERS[i]}={letter_tokens[i]}" for i in range(len(LETTERS))))
+
+    prefixes = {s: build_prefix(s, info["dev"]) for s, info in ds["subjects"].items()}
+
+    correct = 0
+    t_start = time.perf_counter()
+    for idx, item in enumerate(questions):
+        prefix = prefixes.get(item["subject"], "")
+        prompt = prefix + item["question"] + "\n"
+        for i, c in enumerate(item["choices"][:len(LETTERS)]):
+            prompt += f"{LETTERS[i]}. {c}\n"
+        prompt += "Answer:"
+        n = min(len(item["choices"]), len(LETTERS))
+        pred = predict(model, tokenizer, prompt, letter_tokens[:n])
+        if pred == item["answer"]: correct += 1
+        if (idx + 1) % 20 == 0:
+            elapsed = time.perf_counter() - t_start
+            eta = elapsed / (idx + 1) * (len(questions) - idx - 1)
+            print(f"[{idx+1}/{len(questions)}] {correct}/{idx+1} = {correct/(idx+1)*100:.1f}% | {elapsed:.0f}s, ETA {eta:.0f}s")
+    print(f"\n=== Python: {correct}/{len(questions)} = {correct/len(questions)*100:.1f}% ===")
+
+if __name__ == "__main__":
+    main()

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
+        "version" : "0.31.4"
       }
     },
     {

--- a/Sources/Gemma4CLI/EvalCommand.swift
+++ b/Sources/Gemma4CLI/EvalCommand.swift
@@ -1,0 +1,363 @@
+// Eval MMLU 5-shot multi-choice style lm-eval-harness.
+//
+// Format standard (subject-aware few-shot) :
+//   The following are multiple choice questions (with answers) about <subject>.
+//
+//   <dev_q1>
+//   A. ...
+//   B. ...
+//   C. ...
+//   D. ...
+//   Answer: <gold_letter>
+//
+//   [5 exemples du dev split]
+//
+//   <test_q>
+//   A. ...
+//   B. ...
+//   C. ...
+//   D. ...
+//   Answer:
+//
+// Le modele predit un token unique parmi " A"/" B"/" C"/" D" (avec espace
+// leading). On compare les logits a ces 4 positions de vocab et on prend
+// l'argmax.
+
+import ArgumentParser
+import Foundation
+import Gemma4Swift
+import MLX
+import MLXLMCommon
+import MLXLLM
+import Tokenizers
+
+struct EvalMmlu: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "eval-mmlu",
+        abstract: "Eval MMLU 5-shot (style lm-eval-harness)"
+    )
+
+    @Option(name: .long, help: "Chemin local vers le modele")
+    var modelPath: String
+
+    @Option(name: .long, help: "Fichier JSON 5-shot (avec dev examples par sujet)")
+    var dataset: String = "/tmp/mmlu_5shot.json"
+
+    @Option(name: .customLong("quantize-bits"), help: "Quantification a la volee des poids (4/6/8)")
+    var quantizeBits: Int?
+
+    @Option(name: .customLong("quantize-group-size"), help: "Group size (defaut 64)")
+    var quantizeGroupSize: Int = 64
+
+    @Option(name: .customLong("quantize-mode"), help: "Mode : affine | mxfp4 | mxfp8")
+    var quantizeMode: String = "affine"
+
+    @Option(name: .long, help: "Bits de quantization KV cache TurboQuant (3 ou 4)")
+    var kvBits: Int?
+
+    @Option(name: .long, help: "Limite le nombre de questions")
+    var limit: Int?
+
+    @Option(name: .long, help: "Verbose : print chaque question")
+    var verbose: Bool = false
+
+    @Flag(name: .long, help: "Mode Chain-of-Thought : utilise cot_content pour 5-shot + generation libre + parse 'answer is (X)'")
+    var cot: Bool = false
+
+    @Option(name: .long, help: "Max tokens generes par question en mode CoT")
+    var cotMaxTokens: Int = 512
+
+    struct MmluItem: Codable {
+        let subject: String
+        let question: String
+        let choices: [String]
+        let answer: Int
+    }
+
+    struct DevItem: Codable {
+        let q: String
+        let c: [String]
+        let a: Int
+        let cot: String?
+    }
+
+    struct SubjectInfo: Codable {
+        let dev: [DevItem]
+    }
+
+    struct MmluDataset: Codable {
+        let subjects: [String: SubjectInfo]
+        let questions: [MmluItem]
+    }
+
+    func run() async throws {
+        // Support jusqu'a 10 choix pour MMLU Pro (A..J)
+        let letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: dataset))
+        let ds = try JSONDecoder().decode(MmluDataset.self, from: data)
+        var items = ds.questions
+        if let limit = limit { items = Array(items.prefix(limit)) }
+        print("Loaded \(items.count) test questions, \(ds.subjects.count) subjects (5-shot dev)")
+
+        // Pre-construit les prefixes 5-shot par sujet (CoT ou non).
+        var prefixBySubject: [String: String] = [:]
+        for (subj, info) in ds.subjects {
+            let subjFmt = subj.replacingOccurrences(of: "_", with: " ")
+            var p = "The following are multiple choice questions (with answers) about \(subjFmt).\n\n"
+            for d in info.dev {
+                p += "\(d.q)\n"
+                for (i, c) in d.c.enumerated() where i < letters.count {
+                    p += "\(letters[i]). \(c)\n"
+                }
+                if cot, let cotText = d.cot, !cotText.isEmpty {
+                    // cotText commence souvent par "A: Let's think step by step..."
+                    p += "\(cotText)\n\n"
+                } else {
+                    p += "Answer: \(letters[d.a])\n\n"
+                }
+            }
+            prefixBySubject[subj] = p
+        }
+
+        // Load model
+        await Gemma4Registration.register()
+        let url = URL(fileURLWithPath: modelPath)
+        let container = try await loadModelContainer(from: url, using: LocalTokenizerLoader())
+
+        // OTF quant
+        if let bits = quantizeBits {
+            guard let mode = Gemma4OnTheFlyQuantization.Mode(rawValue: quantizeMode) else {
+                print("Erreur: --quantize-mode invalide")
+                throw ExitCode.failure
+            }
+            let count = await container.perform { context in
+                Gemma4OnTheFlyQuantization.apply(
+                    to: context.model, bits: bits,
+                    groupSize: self.quantizeGroupSize, mode: mode
+                )
+            }
+            print("OTF quant: \(count) modules (\(bits)-bit, \(mode.rawValue), g=\(quantizeGroupSize))")
+        }
+
+        // Resolve les 4 token IDs pour " A", " B", " C", " D"
+        // (les exemples 5-shot conditionnent le modele a sortir un single letter)
+        let letterTokens: [Int] = await container.perform { context in
+            return letters.map { l in
+                let ids = context.tokenizer.encode(text: " \(l)")
+                // Skip BOS, prendre le dernier token de " A"
+                return ids.last!
+            }
+        }
+        print("Letter token IDs : A=\(letterTokens[0]) B=\(letterTokens[1]) C=\(letterTokens[2]) D=\(letterTokens[3])")
+
+        let kvBitsParam = self.kvBits
+
+        var correctByCfg = ["bf16-kv": 0]
+        var totalByCfg = ["bf16-kv": 0]
+        if kvBitsParam != nil { correctByCfg["TQ-kv"] = 0; totalByCfg["TQ-kv"] = 0 }
+        var bySubjectCorrect: [String: Int] = [:]
+        var bySubjectTotal: [String: Int] = [:]
+        var sameAnswer = 0
+
+        let startTime = Date()
+
+        let cfgs: [(String, Int?)]
+        if let kv = kvBitsParam {
+            cfgs = [("bf16-kv", nil), ("TQ-kv", kv)]
+        } else {
+            cfgs = [("bf16-kv", nil)]
+        }
+
+        for (idx, item) in items.enumerated() {
+            // Build le 5-shot prompt
+            let prefix = prefixBySubject[item.subject] ?? ""
+            var prompt = prefix
+            prompt += "\(item.question)\n"
+            for (i, c) in item.choices.enumerated() where i < letters.count {
+                prompt += "\(letters[i]). \(c)\n"
+            }
+            // Format CoT : "A: Let's think step by step." declenche le raisonnement.
+            // Format direct : "Answer:" + logit lookup.
+            if cot {
+                prompt += "A: Let's think step by step."
+            } else {
+                prompt += "Answer:"
+            }
+
+            // On limite l'argmax aux choix VALIDES de cette question
+            let nChoices = min(item.choices.count, letters.count)
+            let candidateTokens = Array(letterTokens.prefix(nChoices))
+
+            var answers: [String: Int] = [:]
+            for (cfgName, kv) in cfgs {
+                let answer: Int
+                if cot {
+                    answer = await Self.predictAnswerCoT(
+                        container: container,
+                        prompt: prompt,
+                        nChoices: nChoices,
+                        maxTokens: self.cotMaxTokens,
+                        kvBits: kv
+                    )
+                } else {
+                    answer = await Self.predictAnswerLogits(
+                        container: container,
+                        prompt: prompt,
+                        letterTokens: candidateTokens,
+                        kvBits: kv
+                    )
+                }
+                answers[cfgName] = answer
+                totalByCfg[cfgName, default: 0] += 1
+                if answer == item.answer {
+                    correctByCfg[cfgName, default: 0] += 1
+                    if cfgName == "bf16-kv" {
+                        bySubjectCorrect[item.subject, default: 0] += 1
+                    }
+                }
+            }
+            bySubjectTotal[item.subject, default: 0] += 1
+
+            if cfgs.count == 2 && answers["bf16-kv"] == answers["TQ-kv"] {
+                sameAnswer += 1
+            }
+
+            if verbose || (idx + 1) % 10 == 0 {
+                let elapsed = Date().timeIntervalSince(startTime)
+                let eta = elapsed / Double(idx + 1) * Double(items.count - idx - 1)
+                func ltr(_ i: Int?) -> String {
+                    guard let i = i, i >= 0 && i < 4 else { return "?" }
+                    return letters[i]
+                }
+                print("[\(idx + 1)/\(items.count)] subj=\(item.subject) gold=\(letters[item.answer]) " +
+                    "bf16=\(ltr(answers["bf16-kv"]))" +
+                    (kvBitsParam != nil ? " TQ=\(ltr(answers["TQ-kv"]))" : "") +
+                    String(format: " | %.1fs elapsed, ETA %.0fs", elapsed, eta))
+            }
+        }
+
+        let elapsed = Date().timeIntervalSince(startTime)
+        print("\n=== Results (\(items.count) questions, 5-shot, \(String(format: "%.1f", elapsed))s) ===")
+        for (cfg, total) in totalByCfg {
+            let correct = correctByCfg[cfg] ?? 0
+            let pct = Double(correct) / Double(total) * 100.0
+            print("  \(cfg): \(correct)/\(total) = \(String(format: "%.1f%%", pct))")
+        }
+        if cfgs.count == 2 {
+            let agreePct = Double(sameAnswer) / Double(items.count) * 100.0
+            print("  Agreement bf16 vs TQ: \(sameAnswer)/\(items.count) = \(String(format: "%.1f%%", agreePct))")
+        }
+        print("\nBy subject (bf16-kv accuracy):")
+        for subj in bySubjectTotal.keys.sorted() {
+            let c = bySubjectCorrect[subj, default: 0]
+            let t = bySubjectTotal[subj]!
+            print("  \(subj): \(c)/\(t)")
+        }
+    }
+
+    /// Mode Chain-of-Thought : greedy generation jusqu'a "The answer is (X)"
+    /// ou EOS. Parse la lettre finale via regex.
+    private static func predictAnswerCoT(
+        container: ModelContainer,
+        prompt: String,
+        nChoices: Int,
+        maxTokens: Int,
+        kvBits: Int?
+    ) async -> Int {
+        let kvBitsArg = kvBits
+        let generated: String = await container.perform { context in
+            let promptIds = context.tokenizer.encode(text: prompt)
+            let inputIds = MLXArray(promptIds.map { Int32($0) })
+            let params = kvBitsArg != nil ? GenerateParameters(kvBits: kvBitsArg) : nil
+            let cache = context.model.newCache(parameters: params)
+
+            // Prefill
+            let prefillOut = context.model(inputIds.reshaped(1, -1), cache: cache)
+            var nextTok = argMax(prefillOut[0..., prefillOut.dim(1) - 1, 0...], axis: -1).item(Int32.self)
+            var genIds: [Int] = [Int(nextTok)]
+
+            for _ in 0 ..< maxTokens - 1 {
+                if nextTok == 1 || nextTok == 106 { break }  // EOS
+                let stepIn = MLXArray([nextTok]).reshaped(1, 1)
+                let out = context.model(stepIn, cache: cache)
+                nextTok = argMax(out[0..., 0, 0...], axis: -1).item(Int32.self)
+                genIds.append(Int(nextTok))
+                // Stop precoce si on detecte "The answer is" pour eviter de continuer.
+                // (decode partiel toutes les ~32 tokens pour limiter le cout)
+                if genIds.count % 32 == 0 {
+                    let partial = context.tokenizer.decode(tokenIds: genIds).lowercased()
+                    if partial.contains("the answer is") { break }
+                }
+            }
+            return context.tokenizer.decode(tokenIds: genIds)
+        }
+
+        return parseLetterAnswer(generated, nChoices: nChoices)
+    }
+
+    /// Parse une reponse CoT pour extraire la lettre choisie.
+    /// Strategie : cherche "answer is (X)" / "answer is X" / "(X)" / fallback first letter.
+    static func parseLetterAnswer(_ text: String, nChoices: Int) -> Int {
+        let letters = "ABCDEFGHIJ"
+        let validLetters = Array(letters.prefix(nChoices))
+        let lower = text.lowercased()
+
+        // Pattern 1 : "answer is (X)" ou "answer is X"
+        for marker in ["answer is (", "answer is *", "answer is **", "answer is "] {
+            if let r = lower.range(of: marker) {
+                let after = text[r.upperBound...]
+                for ch in after.prefix(5) {
+                    if let idx = validLetters.firstIndex(of: ch) { return idx }
+                }
+            }
+        }
+
+        // Pattern 2 : derniere occurrence de "(X)" dans le texte
+        let chars = Array(text)
+        for i in stride(from: chars.count - 1, through: 0, by: -1) {
+            if chars[i] == ")" && i >= 2 && chars[i - 2] == "(" {
+                let ch = chars[i - 1]
+                if let idx = validLetters.firstIndex(of: ch) { return idx }
+            }
+        }
+
+        // Pattern 3 : derniere lettre majuscule isolee (espace avant/apres ou fin)
+        for i in stride(from: chars.count - 1, through: 0, by: -1) {
+            let ch = chars[i]
+            if let idx = validLetters.firstIndex(of: ch) {
+                let prev = i > 0 ? chars[i - 1] : " "
+                let next = i < chars.count - 1 ? chars[i + 1] : " "
+                if !prev.isLetter && !next.isLetter { return idx }
+            }
+        }
+
+        return -1
+    }
+
+    /// Forward complet sur le prompt 5-shot, compare logits a " A"/" B"/" C"/" D".
+    private static func predictAnswerLogits(
+        container: ModelContainer,
+        prompt: String,
+        letterTokens: [Int],
+        kvBits: Int?
+    ) async -> Int {
+        let kvBitsArg = kvBits
+        return await container.perform { context in
+            let promptIds = context.tokenizer.encode(text: prompt)
+            let inputIds = MLXArray(promptIds.map { Int32($0) }).reshaped(1, -1)
+            let params = kvBitsArg != nil ? GenerateParameters(kvBits: kvBitsArg) : nil
+            let cache = context.model.newCache(parameters: params)
+            let logits = context.model(inputIds, cache: cache)
+            // Logits du dernier token = distribution du prochain token (= " A"/" B"/...)
+            let lastLogits = logits[0, logits.dim(1) - 1, 0...]
+            var bestIdx = 0
+            var bestLogit = Float(-Float.infinity)
+            for (i, tok) in letterTokens.enumerated() {
+                let l = lastLogits[tok].item(Float.self)
+                if l > bestLogit { bestLogit = l; bestIdx = i }
+            }
+            return bestIdx
+        }
+    }
+}

--- a/Sources/Gemma4CLI/EvalCommand.swift
+++ b/Sources/Gemma4CLI/EvalCommand.swift
@@ -351,10 +351,13 @@ struct EvalMmlu: AsyncParsableCommand {
             let logits = context.model(inputIds, cache: cache)
             // Logits du dernier token = distribution du prochain token (= " A"/" B"/...)
             let lastLogits = logits[0, logits.dim(1) - 1, 0...]
+            // Gather des candidats en un seul tenseur + UN seul sync via asArray
+            // (evite N appels .item() qui forcent N sync GPU->CPU).
+            let candidateIdx = MLXArray(letterTokens.map { Int32($0) })
+            let candidateLogits = lastLogits.take(candidateIdx, axis: 0).asArray(Float.self)
             var bestIdx = 0
             var bestLogit = Float(-Float.infinity)
-            for (i, tok) in letterTokens.enumerated() {
-                let l = lastLogits[tok].item(Float.self)
+            for (i, l) in candidateLogits.enumerated() {
                 if l > bestLogit { bestLogit = l; bestIdx = i }
             }
             return bestIdx

--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -45,7 +45,7 @@ struct Gemma4CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "gemma4-cli",
         abstract: "Inference Gemma 4 via MLX Swift",
-        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self, MtpDiagVerify.self, MtpTrain.self],
+        subcommands: [Generate.self, Chat.self, Describe.self, Models.self, Download.self, Profile.self, EvalMmlu.self, LoRA.self, MtpSmoke.self, MtpForward.self, MtpGenerate.self, MtpDiagVerify.self, MtpTrain.self],
         defaultSubcommand: Generate.self
     )
 }

--- a/Sources/Gemma4CLI/Gemma4CLI.swift
+++ b/Sources/Gemma4CLI/Gemma4CLI.swift
@@ -150,6 +150,11 @@ struct Download: AsyncParsableCommand {
         "a4b-6bit": "mlx-community/gemma-4-26b-a4b-it-6bit",
         "a4b-8bit": "mlx-community/gemma-4-26b-a4b-it-8bit",
         "a4b-bf16": "mlx-community/gemma-4-26b-a4b-it-bf16",
+        // 12B Unified
+        "12b-4bit": "mlx-community/gemma-4-12B-it-4bit",
+        "12b-6bit": "mlx-community/gemma-4-12B-it-6bit",
+        "12b-8bit": "mlx-community/gemma-4-12B-it-8bit",
+        "12b-bf16": "mlx-community/gemma-4-12B-it-bf16",
     ]
 
     func run() async throws {
@@ -269,6 +274,18 @@ struct Generate: AsyncParsableCommand {
     @Option(name: .long, help: "Block size MTP (drafter genere blockSize-1 tokens par round)")
     var blockSize: Int = 4
 
+    @Option(name: .customLong("quantize-bits"), help: "Quantification a la volee (bits : 4, 6, 8). Applique apres le load, AVANT la generation.")
+    var quantizeBits: Int?
+
+    @Option(name: .customLong("quantize-group-size"), help: "Group size de quantification (defaut 64)")
+    var quantizeGroupSize: Int = 64
+
+    @Option(name: .customLong("quantize-mode"), help: "Mode quantification : affine | mxfp4 | mxfp8")
+    var quantizeMode: String = "affine"
+
+    @Flag(name: .customLong("quantize-text-only"), help: "Si actif: ne quantize QUE le decoder texte (pour multimodal: vision/audio restent en bf16).")
+    var quantizeTextOnly: Bool = false
+
     @Argument(help: "Le prompt utilisateur")
     var prompt: String
 
@@ -293,6 +310,30 @@ struct Generate: AsyncParsableCommand {
 
         let loadTime = Date().timeIntervalSince(startLoad)
         print("Modele charge en \(String(format: "%.1f", loadTime))s")
+
+        // 3b. Quantification a la volee (optionnelle)
+        if let bits = quantizeBits {
+            guard let mode = Gemma4OnTheFlyQuantization.Mode(rawValue: quantizeMode) else {
+                print("Erreur: --quantize-mode doit etre affine|mxfp4|mxfp8")
+                throw ExitCode.failure
+            }
+            let excluded = quantizeTextOnly
+                ? Gemma4OnTheFlyQuantization.multimodalEncoderPrefixes
+                : Gemma4OnTheFlyQuantization.defaultExcludedPathPrefixes
+            let quantStart = Date()
+            let count = await container.perform { context in
+                Gemma4OnTheFlyQuantization.apply(
+                    to: context.model,
+                    bits: bits,
+                    groupSize: self.quantizeGroupSize,
+                    mode: mode,
+                    excludedPathPrefixes: excluded
+                )
+            }
+            let quantTime = Date().timeIntervalSince(quantStart)
+            let scope = quantizeTextOnly ? "text-only" : "all"
+            print("Quantification a la volee (\(scope)): \(count) modules (\(bits)-bit, group=\(quantizeGroupSize), \(mode.rawValue)) en \(String(format: "%.1f", quantTime))s")
+        }
 
         // 4. Stats GPU
         print("GPU: \(MLX.GPU.activeMemory / (1024 * 1024)) Mo actifs, \(MLX.GPU.peakMemory / (1024 * 1024)) Mo pic")
@@ -553,6 +594,18 @@ struct Describe: AsyncParsableCommand {
     @Option(name: .long, help: "Temperature")
     var temperature: Float = 0.3
 
+    @Option(name: .customLong("quantize-bits"), help: "Quantification a la volee (4, 6, 8). Par defaut quantifie aussi les encoders multimodaux (comme mlx-community pre-quant).")
+    var quantizeBits: Int?
+
+    @Option(name: .customLong("quantize-group-size"), help: "Group size (defaut 64)")
+    var quantizeGroupSize: Int = 64
+
+    @Option(name: .customLong("quantize-mode"), help: "Mode : affine | mxfp4 | mxfp8")
+    var quantizeMode: String = "affine"
+
+    @Flag(name: .customLong("quantize-text-only"), help: "Si actif: ne quantize QUE le decoder texte (vision/audio encoders restent en bf16).")
+    var quantizeTextOnly: Bool = false
+
     func run() async throws {
         guard !image.isEmpty || audio != nil || video != nil else {
             print("Erreur: specifiez --image, --audio ou --video")
@@ -572,6 +625,39 @@ struct Describe: AsyncParsableCommand {
         print("Chargement du modele: \(path)")
         let container = try await loadLocalMultimodalModel(path: path)
         print("Modele charge.")
+
+        // 2b. Quantification a la volee (optionnelle).
+        //     Par defaut : quantize tout (Linear + Embedding), comme le pre-quant mlx-community.
+        //     Avec --quantize-text-only : preserve les encoders multimodaux en bf16.
+        if let bits = quantizeBits {
+            guard let mode = Gemma4OnTheFlyQuantization.Mode(rawValue: quantizeMode) else {
+                print("Erreur: --quantize-mode doit etre affine|mxfp4|mxfp8")
+                throw ExitCode.failure
+            }
+            let excluded = quantizeTextOnly
+                ? Gemma4OnTheFlyQuantization.multimodalEncoderPrefixes
+                : Gemma4OnTheFlyQuantization.defaultExcludedPathPrefixes
+            let count = await container.perform { context in
+                Gemma4OnTheFlyQuantization.apply(
+                    to: context.model,
+                    bits: bits,
+                    groupSize: self.quantizeGroupSize,
+                    mode: mode,
+                    excludedPathPrefixes: excluded
+                )
+            }
+            let scope = quantizeTextOnly ? "text-only" : "all"
+            print("On-the-fly quant (\(scope)): \(count) modules (\(bits)-bit, group=\(quantizeGroupSize), \(mode.rawValue))")
+        }
+
+        // 2b. Detecter si modele unified (gemma4_unified, ex: 12B) -> path dedie.
+        let isUnified: Bool = await container.perform { context in
+            context.model is Gemma4UnifiedMultimodalLLMModel
+        }
+        if isUnified {
+            try await runUnified(container: container)
+            return
+        }
 
         // 3. Preparer les inputs multimodaux
         let numImages = image.count
@@ -810,6 +896,244 @@ struct Describe: AsyncParsableCommand {
         } else {
             print("Tokens: \(tokenCount)")
         }
+        print("Temps: \(String(format: "%.2f", elapsed))s, Vitesse: \(String(format: "%.1f", Double(tokenCount) / max(0.01, elapsed))) t/s")
+        print("GPU pic: \(MLX.GPU.peakMemory / (1024 * 1024)) Mo")
+    }
+
+    // MARK: - gemma4_unified (12B) path
+
+    /// Pipeline multimodal pour gemma4_unified (12B) : patches 48x48 + chunks PCM 640.
+    /// Reutilise le meme tokenizer + chat template + boucle generation que le path
+    /// E2B/E4B, mais (1) preprocesse images via patches/positionIds et
+    /// (2) expanse les image_token par le nombre VARIABLE de patches valides.
+    fileprivate func runUnified(container: ModelContainer) async throws {
+        // Recuperer la config vision/audio depuis le modele.
+        let (visionConfig, audioConfig, videoSoftTokensPerFrame): (Gemma4UnifiedVisionConfig?, Gemma4UnifiedAudioConfig?, Int) =
+            await container.perform { context in
+                guard let m = context.model as? Gemma4UnifiedMultimodalLLMModel else {
+                    return (nil, nil, 70)
+                }
+                return (m.config.visionConfig, m.config.audioConfig, m.config.visionSoftTokensPerVideoFrame)
+            }
+
+        // --- 1. Preprocess images ---
+        var imagePatchesList: [MLXArray] = []
+        var imagePositionsList: [MLXArray] = []
+        var validPatchesPerImage: [Int] = []
+
+        if !image.isEmpty {
+            guard let vcfg = visionConfig else {
+                print("Erreur: modele sans vision_config.")
+                throw ExitCode.failure
+            }
+            for imagePath in image {
+                print("Traitement de l'image: \(imagePath)")
+                let imageURL = URL(fileURLWithPath: imagePath)
+                let processed = try Gemma4UnifiedImageProcessor.processImage(url: imageURL, config: vcfg)
+                imagePatchesList.append(processed.patches)
+                imagePositionsList.append(processed.positionIds)
+                validPatchesPerImage.append(processed.validPatches)
+                print("  -> \(processed.validPatches) patches valides (sur \(processed.patches.dim(0)) padded)")
+            }
+        }
+        let hasImage = !imagePatchesList.isEmpty
+
+        // --- 1b. Preprocess video ---
+        var videoFramePatchesList: [MLXArray] = []
+        var videoFramePositionsList: [MLXArray] = []
+        var videoValidPatchesPerFrame: [Int] = []
+        var videoTimestamps: [Double] = []
+
+        if let videoPath = video {
+            guard let vcfg = visionConfig else {
+                print("Erreur: modele sans vision_config.")
+                throw ExitCode.failure
+            }
+            print("Traitement de la video: \(videoPath)")
+            let videoURL = URL(fileURLWithPath: videoPath)
+            let processed = try await Gemma4UnifiedVideoProcessor.processVideo(
+                url: videoURL, config: vcfg, softTokensPerFrame: videoSoftTokensPerFrame
+            )
+            for f in processed.frames {
+                videoFramePatchesList.append(f.patches)
+                videoFramePositionsList.append(f.positionIds)
+                videoValidPatchesPerFrame.append(f.validPatches)
+            }
+            videoTimestamps = processed.timestamps
+            print("  -> \(processed.frames.count) frames, \(videoSoftTokensPerFrame) tokens/frame max, fps source=\(String(format: "%.1f", processed.sourceFPS))")
+        }
+        let hasVideo = !videoFramePatchesList.isEmpty
+        let numVideoFrames = videoFramePatchesList.count
+
+        // --- 2. Preprocess audio ---
+        var audioFeatures: Gemma4UnifiedAudioProcessor.ProcessedAudio?
+        if let audioPath = audio {
+            guard let acfg = audioConfig else {
+                print("Erreur: modele sans audio_config.")
+                throw ExitCode.failure
+            }
+            print("Traitement de l'audio: \(audioPath)")
+            let audioURL = URL(fileURLWithPath: audioPath)
+            audioFeatures = try await Gemma4UnifiedAudioProcessor.processAudio(url: audioURL, config: acfg)
+            print("  -> \(audioFeatures!.numTokens) tokens (\(String(format: "%.2f", audioFeatures!.durationSeconds))s)")
+        }
+        let hasAudio = audioFeatures != nil
+        let numAudioTokens = audioFeatures?.numTokens ?? 0
+
+        // --- 3. Construire le contenu avec placeholders ---
+        var contentParts: [String] = []
+        if hasImage {
+            for _ in 0 ..< imagePatchesList.count {
+                contentParts.append("<|image|>")
+            }
+        }
+        if hasVideo {
+            for i in 0 ..< numVideoFrames {
+                let ts = Gemma4VideoProcessor.formatTimestamp(videoTimestamps[i])
+                contentParts.append("\(ts)\n<|video|>")
+            }
+        }
+        if hasAudio && numAudioTokens > 0 {
+            contentParts.append("<|audio|>")
+        }
+        contentParts.append(prompt)
+        let content = contentParts.joined(separator: "\n")
+
+        let messages: [[String: String]] = [["role": "user", "content": content]]
+        var tokenIds: [Int] = try await container.perform { context in
+            try context.tokenizer.applyChatTemplate(messages: messages)
+        }
+
+        // --- 4. Expanser les placeholders en respectant validPatches[i] par image/frame ---
+        let imageTokenId = Int(Gemma4Processor.imageTokenId)
+        let videoTokenId = Int(Gemma4Processor.videoTokenId)
+        let audioTokenId = Int(Gemma4Processor.audioTokenId)
+        let boiTokenId = Int(Gemma4Processor.boiTokenId)
+        let eoiTokenId = Int(Gemma4Processor.eoiTokenId)
+        let boaTokenId = Int(Gemma4Processor.boaTokenId)
+        let eoaTokenId = Int(Gemma4Processor.eoaTokenId)
+
+        var expandedTokenIds: [Int] = []
+        var imageIdx = 0
+        var videoIdx = 0
+        for tid in tokenIds {
+            if tid == imageTokenId {
+                expandedTokenIds.append(boiTokenId)
+                let n = imageIdx < validPatchesPerImage.count ? validPatchesPerImage[imageIdx] : 0
+                for _ in 0 ..< n { expandedTokenIds.append(imageTokenId) }
+                expandedTokenIds.append(eoiTokenId)
+                imageIdx += 1
+            } else if tid == videoTokenId {
+                expandedTokenIds.append(boiTokenId)
+                let n = videoIdx < videoValidPatchesPerFrame.count ? videoValidPatchesPerFrame[videoIdx] : 0
+                for _ in 0 ..< n { expandedTokenIds.append(videoTokenId) }
+                expandedTokenIds.append(eoiTokenId)
+                videoIdx += 1
+            } else if tid == audioTokenId {
+                expandedTokenIds.append(boaTokenId)
+                for _ in 0 ..< numAudioTokens { expandedTokenIds.append(audioTokenId) }
+                expandedTokenIds.append(eoaTokenId)
+            } else {
+                expandedTokenIds.append(tid)
+            }
+        }
+        tokenIds = expandedTokenIds
+        let inputIds = MLXArray(tokenIds.map { Int32($0) })
+
+        let imgCount = tokenIds.filter { $0 == imageTokenId }.count
+        let vidCount = tokenIds.filter { $0 == videoTokenId }.count
+        let audCount = tokenIds.filter { $0 == audioTokenId }.count
+        print("  image_token: \(imgCount), video_token: \(vidCount), audio_token: \(audCount), total: \(inputIds.shape[0])")
+
+        // --- 5. Stack patches/positions + injection ---
+        let stackedPatches: MLXArray? = imagePatchesList.isEmpty ? nil : stacked(imagePatchesList, axis: 0)
+        let stackedPositions: MLXArray? = imagePositionsList.isEmpty ? nil : stacked(imagePositionsList, axis: 0)
+        let stackedVideoPatches: MLXArray? = videoFramePatchesList.isEmpty ? nil : stacked(videoFramePatchesList, axis: 0)
+        let stackedVideoPositions: MLXArray? = videoFramePositionsList.isEmpty ? nil : stacked(videoFramePositionsList, axis: 0)
+
+        nonisolated(unsafe) let finalPatches = stackedPatches
+        nonisolated(unsafe) let finalPositions = stackedPositions
+        nonisolated(unsafe) let finalValid = validPatchesPerImage
+        nonisolated(unsafe) let finalVideoPatches = stackedVideoPatches
+        nonisolated(unsafe) let finalVideoPositions = stackedVideoPositions
+        nonisolated(unsafe) let finalVideoValid = videoValidPatchesPerFrame
+        nonisolated(unsafe) let finalAudio = audioFeatures
+
+        await container.perform { context in
+            guard let model = context.model as? Gemma4UnifiedMultimodalLLMModel else { return }
+            if finalPatches != nil {
+                model.pendingPixelPatches = finalPatches
+                model.pendingImagePositionIds = finalPositions
+                model.pendingValidPatches = finalValid
+            }
+            if finalVideoPatches != nil {
+                model.pendingVideoFramePatches = finalVideoPatches
+                model.pendingVideoFramePositionIds = finalVideoPositions
+                model.pendingVideoValidPatches = finalVideoValid
+            }
+            if let af = finalAudio {
+                model.pendingAudioFeatures = af.features
+                model.pendingAudioMask = af.mask
+            }
+        }
+
+        print("\n--- Generation multimodale (gemma4_unified) ---")
+        if hasImage { print("  Mode: vision (\(imagePatchesList.count) image(s))") }
+        if hasVideo { print("  Mode: video (\(numVideoFrames) frames)") }
+        if hasAudio { print("  Mode: audio") }
+        print("  Prompt: \(prompt)")
+        print("---")
+
+        // --- 6. Generation (meme boucle que path E2B/E4B) ---
+        let startTime = Date()
+        var tokenCount = 0
+        nonisolated(unsafe) let capturedInputIds = inputIds
+        let tokenFilter = Gemma4TokenFilter(mode: .disabled)
+
+        let result = try await container.perform { context in
+            var generatedTokens: [Int] = []
+            let params = GenerateParameters(
+                maxTokens: self.maxTokens,
+                temperature: self.temperature,
+                topP: 0.95
+            )
+            let cache = context.model.newCache(parameters: params)
+
+            let prefillOutput = context.model(capturedInputIds.reshaped(1, -1), cache: cache)
+            var nextToken = argMax(prefillOutput[0..., prefillOutput.dim(1) - 1, 0...], axis: -1).item(Int32.self)
+
+            let maxTotalTokens = self.maxTokens * 3
+            var visibleTokens = 0
+
+            for _ in 0 ..< maxTotalTokens {
+                generatedTokens.append(Int(nextToken))
+                let text = context.tokenizer.decode(tokenIds: [Int(nextToken)])
+                let filtered = tokenFilter.process(tokenId: nextToken, text: text)
+                if !filtered.isEmpty {
+                    print(filtered, terminator: "")
+                    fflush(stdout)
+                    visibleTokens += 1
+                }
+                if tokenFilter.isEOS(nextToken) { break }
+                if visibleTokens >= self.maxTokens { break }
+
+                let nextInput = MLXArray([nextToken]).reshaped(1, 1)
+                let output = context.model(nextInput, cache: cache)
+                if self.temperature <= 0.01 {
+                    nextToken = argMax(output[0..., 0, 0...], axis: -1).item(Int32.self)
+                } else {
+                    let logits = output[0..., 0, 0...] / self.temperature
+                    let probs = softmax(logits, axis: -1)
+                    nextToken = MLXRandom.categorical(log(probs)).item(Int32.self)
+                }
+            }
+            return generatedTokens
+        }
+
+        tokenCount = result.count
+        let elapsed = Date().timeIntervalSince(startTime)
+        print("\n\n--- Stats ---")
+        print("Tokens: \(tokenCount)")
         print("Temps: \(String(format: "%.2f", elapsed))s, Vitesse: \(String(format: "%.1f", Double(tokenCount) / max(0.01, elapsed))) t/s")
         print("GPU pic: \(MLX.GPU.peakMemory / (1024 * 1024)) Mo")
     }

--- a/Sources/Gemma4CLI/ProfileCommand.swift
+++ b/Sources/Gemma4CLI/ProfileCommand.swift
@@ -56,6 +56,18 @@ struct ProfileRun: AsyncParsableCommand {
     @Option(name: .long, help: "Bits de quantisation KV cache TurboQuant (3, 4)")
     var kvBits: Int?
 
+    @Option(name: .customLong("quantize-bits"), help: "Quantification a la volee des poids (4, 6, 8). Mesure perf apres quantization.")
+    var quantizeBits: Int?
+
+    @Option(name: .customLong("quantize-group-size"), help: "Group size de quantization (defaut 64)")
+    var quantizeGroupSize: Int = 64
+
+    @Option(name: .customLong("quantize-mode"), help: "Mode quantization : affine | mxfp4 | mxfp8")
+    var quantizeMode: String = "affine"
+
+    @Flag(name: .customLong("quantize-text-only"), help: "Si actif: ne quantize QUE le decoder texte.")
+    var quantizeTextOnly: Bool = false
+
     @Option(name: .long, help: "Repertoire de sortie pour les traces")
     var output: String?
 
@@ -86,6 +98,29 @@ struct ProfileRun: AsyncParsableCommand {
             throw ExitCode.failure
         }
         let container = try await loadLocalModel(path: path)
+
+        // Quantification a la volee : ajoute le compte dans la phase load.
+        if let bits = quantizeBits {
+            guard let mode = Gemma4OnTheFlyQuantization.Mode(rawValue: quantizeMode) else {
+                print("Erreur: --quantize-mode doit etre affine|mxfp4|mxfp8")
+                throw ExitCode.failure
+            }
+            let excluded = quantizeTextOnly
+                ? Gemma4OnTheFlyQuantization.multimodalEncoderPrefixes
+                : Gemma4OnTheFlyQuantization.defaultExcludedPathPrefixes
+            let count = await container.perform { context in
+                Gemma4OnTheFlyQuantization.apply(
+                    to: context.model,
+                    bits: bits,
+                    groupSize: self.quantizeGroupSize,
+                    mode: mode,
+                    excludedPathPrefixes: excluded
+                )
+            }
+            let scope = quantizeTextOnly ? "text-only" : "all"
+            session.metadata["onTheFlyQuantization"] = "\(bits)-bit g=\(quantizeGroupSize) \(mode.rawValue) scope=\(scope)"
+            print("On-the-fly quantization (\(scope)): \(count) modules (\(bits)-bit, group=\(quantizeGroupSize), \(mode.rawValue))")
+        }
 
         session.endPhase("1. Model Loading", category: .modelLoad)
 

--- a/Sources/Gemma4Swift/Configuration/Gemma4Config.swift
+++ b/Sources/Gemma4Swift/Configuration/Gemma4Config.swift
@@ -46,11 +46,30 @@ public struct Gemma4Config: Codable {
             textConfig = try Gemma4TextConfig(from: decoder)
         }
 
-        // Tolerant decoding: variantes (e.g. gemma4_unified) exposent un schema
-        // vision/audio reduit. On accepte de loader sans encodeurs multimodaux
-        // plutot que d'echouer le chargement entier (path text-only reste OK).
-        visionConfig = (try? container.decodeIfPresent(Gemma4VisionConfig.self, forKey: .visionConfig)) ?? nil
-        audioConfig = (try? container.decodeIfPresent(Gemma4AudioConfig.self, forKey: .audioConfig)) ?? nil
+        // Tolerant decoding pour les variantes (e.g. gemma4_unified) qui exposent
+        // un schema vision/audio reduit. On loggue les erreurs de decoding pour
+        // ne pas masquer les vrais bugs (typos, types incorrects) tout en
+        // permettant le fallback text-only.
+        if container.contains(.visionConfig) {
+            do {
+                visionConfig = try container.decode(Gemma4VisionConfig.self, forKey: .visionConfig)
+            } catch {
+                FileHandle.standardError.write(Data("[Gemma4Config] vision_config present but decode failed (\(error)); fallback to text-only\n".utf8))
+                visionConfig = nil
+            }
+        } else {
+            visionConfig = nil
+        }
+        if container.contains(.audioConfig) {
+            do {
+                audioConfig = try container.decode(Gemma4AudioConfig.self, forKey: .audioConfig)
+            } catch {
+                FileHandle.standardError.write(Data("[Gemma4Config] audio_config present but decode failed (\(error)); fallback to text-only\n".utf8))
+                audioConfig = nil
+            }
+        } else {
+            audioConfig = nil
+        }
         imageTokenId = try container.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
         audioTokenId = try container.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
         videoTokenId = try container.decodeIfPresent(Int.self, forKey: .videoTokenId) ?? 258884

--- a/Sources/Gemma4Swift/Configuration/Gemma4Config.swift
+++ b/Sources/Gemma4Swift/Configuration/Gemma4Config.swift
@@ -46,8 +46,11 @@ public struct Gemma4Config: Codable {
             textConfig = try Gemma4TextConfig(from: decoder)
         }
 
-        visionConfig = try container.decodeIfPresent(Gemma4VisionConfig.self, forKey: .visionConfig)
-        audioConfig = try container.decodeIfPresent(Gemma4AudioConfig.self, forKey: .audioConfig)
+        // Tolerant decoding: variantes (e.g. gemma4_unified) exposent un schema
+        // vision/audio reduit. On accepte de loader sans encodeurs multimodaux
+        // plutot que d'echouer le chargement entier (path text-only reste OK).
+        visionConfig = (try? container.decodeIfPresent(Gemma4VisionConfig.self, forKey: .visionConfig)) ?? nil
+        audioConfig = (try? container.decodeIfPresent(Gemma4AudioConfig.self, forKey: .audioConfig)) ?? nil
         imageTokenId = try container.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
         audioTokenId = try container.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
         videoTokenId = try container.decodeIfPresent(Int.self, forKey: .videoTokenId) ?? 258884

--- a/Sources/Gemma4Swift/Configuration/Gemma4UnifiedAudioConfig.swift
+++ b/Sources/Gemma4Swift/Configuration/Gemma4UnifiedAudioConfig.swift
@@ -1,0 +1,38 @@
+// Config audio pour gemma4_unified (12B) — projection directe sans Conformer
+
+import Foundation
+
+/// Configuration de l'audio embedder de gemma4_unified.
+///
+/// Contraste avec [[Gemma4AudioConfig]] (E2B/E4B Conformer) : ici il n'y a
+/// pas d'encodeur, juste une projection lineaire depuis des chunks de samples
+/// PCM bruts (audioSamplesPerToken = 640 samples a 16kHz = 40ms par token).
+public struct Gemma4UnifiedAudioConfig: Codable, Sendable {
+    public let modelType: String
+    /// Dimension d'entree du projector (640 par defaut).
+    public let audioEmbedDim: Int
+    /// Nombre de samples PCM bruts groupes en un token audio (640 -> 40ms a 16kHz).
+    public let audioSamplesPerToken: Int
+    public let hiddenSize: Int
+    public let outputProjDims: Int
+    public let rmsNormEps: Float
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case audioEmbedDim = "audio_embed_dim"
+        case audioSamplesPerToken = "audio_samples_per_token"
+        case hiddenSize = "hidden_size"
+        case outputProjDims = "output_proj_dims"
+        case rmsNormEps = "rms_norm_eps"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_unified_audio"
+        audioEmbedDim = try c.decodeIfPresent(Int.self, forKey: .audioEmbedDim) ?? 640
+        audioSamplesPerToken = try c.decodeIfPresent(Int.self, forKey: .audioSamplesPerToken) ?? 640
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? audioEmbedDim
+        outputProjDims = try c.decodeIfPresent(Int.self, forKey: .outputProjDims) ?? audioEmbedDim
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+    }
+}

--- a/Sources/Gemma4Swift/Configuration/Gemma4UnifiedConfig.swift
+++ b/Sources/Gemma4Swift/Configuration/Gemma4UnifiedConfig.swift
@@ -1,0 +1,64 @@
+// Top-level config pour gemma4_unified (12B)
+// Garde Gemma4TextConfig en commun avec gemma4 — seuls vision/audio changent.
+
+import Foundation
+
+/// Configuration top-level de gemma4_unified (modele 12B).
+///
+/// Reutilise [[Gemma4TextConfig]] (le decoder texte est identique a gemma4)
+/// mais swap vision/audio par les variantes encoder-free unified.
+public struct Gemma4UnifiedConfig: Decodable, @unchecked Sendable {
+    public let modelType: String
+    public let textConfig: Gemma4TextConfig
+    public let visionConfig: Gemma4UnifiedVisionConfig?
+    public let audioConfig: Gemma4UnifiedAudioConfig?
+    public let imageTokenId: Int
+    public let audioTokenId: Int
+    public let videoTokenId: Int
+    public let boiTokenId: Int
+    public let eoiTokenId: Int
+    public let boaTokenId: Int
+    public let eoaTokenId: Int
+    public let visionSoftTokensPerImage: Int
+    public let visionSoftTokensPerVideoFrame: Int
+    public let tieWordEmbeddings: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case textConfig = "text_config"
+        case visionConfig = "vision_config"
+        case audioConfig = "audio_config"
+        case imageTokenId = "image_token_id"
+        case audioTokenId = "audio_token_id"
+        case videoTokenId = "video_token_id"
+        case boiTokenId = "boi_token_id"
+        case eoiTokenId = "eoi_token_id"
+        case boaTokenId = "boa_token_id"
+        case eoaTokenIdRaw = "eoa_token_id"
+        case eoaTokenIndex = "eoa_token_index"
+        case visionSoftTokensPerImage = "vision_soft_tokens_per_image"
+        case visionSoftTokensPerVideoFrame = "vision_soft_tokens_per_video_frame"
+        case tieWordEmbeddings = "tie_word_embeddings"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_unified"
+        textConfig = try c.decode(Gemma4TextConfig.self, forKey: .textConfig)
+        visionConfig = try c.decodeIfPresent(Gemma4UnifiedVisionConfig.self, forKey: .visionConfig)
+        audioConfig = try c.decodeIfPresent(Gemma4UnifiedAudioConfig.self, forKey: .audioConfig)
+        imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
+        audioTokenId = try c.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
+        videoTokenId = try c.decodeIfPresent(Int.self, forKey: .videoTokenId) ?? 258884
+        boiTokenId = try c.decodeIfPresent(Int.self, forKey: .boiTokenId) ?? 255999
+        eoiTokenId = try c.decodeIfPresent(Int.self, forKey: .eoiTokenId) ?? 258882
+        boaTokenId = try c.decodeIfPresent(Int.self, forKey: .boaTokenId) ?? 256000
+        // gemma4_unified utilise "eoa_token_index" si "eoa_token_id" absent
+        let eoaRaw = try c.decodeIfPresent(Int.self, forKey: .eoaTokenIdRaw)
+        let eoaIdx = try c.decodeIfPresent(Int.self, forKey: .eoaTokenIndex)
+        eoaTokenId = eoaRaw ?? eoaIdx ?? 258883
+        visionSoftTokensPerImage = try c.decodeIfPresent(Int.self, forKey: .visionSoftTokensPerImage) ?? 280
+        visionSoftTokensPerVideoFrame = try c.decodeIfPresent(Int.self, forKey: .visionSoftTokensPerVideoFrame) ?? 70
+        tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+    }
+}

--- a/Sources/Gemma4Swift/Configuration/Gemma4UnifiedVisionConfig.swift
+++ b/Sources/Gemma4Swift/Configuration/Gemma4UnifiedVisionConfig.swift
@@ -1,0 +1,57 @@
+// Config vision pour gemma4_unified (12B) — encoder-free patch embedder
+
+import Foundation
+
+/// Configuration du vision_embedder de gemma4_unified.
+///
+/// Contraste avec [[Gemma4VisionConfig]] (E2B/E4B) qui decrit un SigLIP complet :
+/// ici l'encodeur est un simple patch-projector (LN -> Linear -> LN -> +pos -> LN).
+public struct Gemma4UnifiedVisionConfig: Codable, Sendable {
+    public let modelType: String
+    /// Taille du patch "model" en pixels (48 par defaut).
+    /// L'image est decoupee en patches de modelPatchSize x modelPatchSize x 3.
+    public let modelPatchSize: Int
+    /// Taille du patch fin (16) — utilise par le preprocessor pour aspect-ratio + pooling.
+    public let patchSize: Int
+    /// Kernel de pooling (3) — modelPatchSize = patchSize * poolingKernelSize.
+    public let poolingKernelSize: Int
+    /// Dimension d'embedding interne (3840 pour 12B).
+    public let mmEmbedDim: Int
+    /// Taille du tableau de pos_embedding par axe (1120) — supporte x ou y jusqu'a 1120.
+    public let mmPosembSize: Int
+    /// Nombre de soft tokens par image dans la sequence texte (280).
+    public let numSoftTokens: Int
+    public let outputProjDims: Int
+    public let rmsNormEps: Float
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case modelPatchSize = "model_patch_size"
+        case patchSize = "patch_size"
+        case poolingKernelSize = "pooling_kernel_size"
+        case mmEmbedDim = "mm_embed_dim"
+        case mmPosembSize = "mm_posemb_size"
+        case numSoftTokens = "num_soft_tokens"
+        case outputProjDims = "output_proj_dims"
+        case rmsNormEps = "rms_norm_eps"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_unified_vision"
+        modelPatchSize = try c.decodeIfPresent(Int.self, forKey: .modelPatchSize) ?? 48
+        patchSize = try c.decodeIfPresent(Int.self, forKey: .patchSize) ?? 16
+        poolingKernelSize = try c.decodeIfPresent(Int.self, forKey: .poolingKernelSize) ?? 3
+        mmEmbedDim = try c.decodeIfPresent(Int.self, forKey: .mmEmbedDim) ?? 3840
+        mmPosembSize = try c.decodeIfPresent(Int.self, forKey: .mmPosembSize) ?? 1120
+        numSoftTokens = try c.decodeIfPresent(Int.self, forKey: .numSoftTokens) ?? 280
+        outputProjDims = try c.decodeIfPresent(Int.self, forKey: .outputProjDims) ?? (mmEmbedDim)
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+    }
+
+    /// Dimension d'un patch flatten : modelPatchSize * modelPatchSize * 3
+    public var patchDim: Int { modelPatchSize * modelPatchSize * 3 }
+
+    /// Nombre maximum de patches accepte par le preprocessor.
+    public var maxPatches: Int { numSoftTokens * poolingKernelSize * poolingKernelSize }
+}

--- a/Sources/Gemma4Swift/Pipeline/AudioProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/AudioProcessor.swift
@@ -88,8 +88,9 @@ public enum Gemma4AudioProcessor {
         return min(t, maxAudioTokens)
     }
 
-    /// Charge l'audio en PCM float32 mono 16kHz
-    static func loadAudioPCM(url: URL) async throws -> [Float] {
+    /// Charge l'audio en PCM float32 mono 16kHz.
+    /// Public car reutilise par [[Gemma4UnifiedAudioProcessor]].
+    public static func loadAudioPCM(url: URL) async throws -> [Float] {
         let file = try AVAudioFile(forReading: url)
         let origFormat = file.processingFormat
         let frameCount = AVAudioFrameCount(file.length)

--- a/Sources/Gemma4Swift/Pipeline/CGImageLoader.swift
+++ b/Sources/Gemma4Swift/Pipeline/CGImageLoader.swift
@@ -1,0 +1,32 @@
+// Helper partage entre les processeurs d'image (Gemma4ImageProcessor pour
+// E2B/E4B SigLIP et Gemma4UnifiedImageProcessor pour 12B Unified) — evite
+// de dupliquer le pattern AppKit/UIKit -> CGImage.
+
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+import CoreGraphics
+import Foundation
+
+public enum Gemma4CGImageLoader {
+    /// Charge une image depuis une URL et renvoie son CGImage en utilisant
+    /// la pile graphique native (NSImage sur macOS, UIImage sur iOS).
+    public static func load(from url: URL) throws -> CGImage {
+        #if canImport(AppKit)
+        guard let nsImage = NSImage(contentsOf: url),
+              let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw ImageProcessingError.cannotLoadImage(url.path)
+        }
+        return cgImage
+        #elseif canImport(UIKit)
+        guard let data = try? Data(contentsOf: url),
+              let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else {
+            throw ImageProcessingError.cannotLoadImage(url.path)
+        }
+        return cgImage
+        #endif
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4OnTheFlyQuantization.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4OnTheFlyQuantization.swift
@@ -73,12 +73,16 @@ public enum Gemma4OnTheFlyQuantization {
             return 0
         }
 
-        // mxfp4/mxfp8 imposent group_size=32 cote MLX. On corrige silencieusement.
+        // mxfp4/mxfp8 imposent group_size=32 cote MLX. On corrige avec warning
+        // visible en stderr (les pipelines de bench grep parfois sur stdout
+        // uniquement et rateraient un print silencieux).
         var effectiveGroupSize = groupSize
         switch mode {
         case .mxfp4, .mxfp8:
             if effectiveGroupSize != 32 {
-                print("[OnTheFlyQuantization] \(mode.rawValue) requiert group_size=32, override")
+                let msg = "[OnTheFlyQuantization] WARNING: \(mode.rawValue) requires group_size=32, " +
+                    "overriding user value \(effectiveGroupSize) → 32\n"
+                FileHandle.standardError.write(Data(msg.utf8))
                 effectiveGroupSize = 32
             }
         case .affine:

--- a/Sources/Gemma4Swift/Pipeline/Gemma4OnTheFlyQuantization.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4OnTheFlyQuantization.swift
@@ -1,0 +1,119 @@
+// Quantification a la volee post-chargement.
+//
+// Utilite : benchmarker une famille bf16 sous plusieurs configurations
+// (4/6/8-bit, group_size, mode) sans avoir a telecharger une variante
+// pre-quantisee par config. Equivalent du `nn.quantize(...)` Python.
+
+import Foundation
+import MLX
+import MLXNN
+import MLXLMCommon
+
+public enum Gemma4OnTheFlyQuantization {
+
+    public enum Mode: String, Sendable {
+        case affine
+        case mxfp4
+        case mxfp8
+
+        var mlxMode: QuantizationMode {
+            switch self {
+            case .affine: return .affine
+            case .mxfp4: return .mxfp4
+            case .mxfp8: return .mxfp8
+            }
+        }
+    }
+
+    /// Defaut : pas d'exclusion. Tous les Linear/Embedding sont quantifies,
+    /// y compris les encoders vision/audio. Cela correspond au comportement
+    /// des checkpoints pre-quantifies mlx-community (qui quantifient aussi
+    /// `vision_embedder.patch_dense`, `embed_vision.embedding_projection`, etc.).
+    ///
+    /// Si tu veux preserver les encoders multimodaux en pleine precision (par
+    /// exemple pour isoler l'impact de la quantization sur le decoder texte
+    /// uniquement), passe explicitement les prefixes via `excludedPathPrefixes`.
+    public static let defaultExcludedPathPrefixes: [String] = []
+
+    /// Prefixes des encoders multimodaux — utile pour "decoder texte seul".
+    /// A passer EXPLICITEMENT a `apply(...)` si on veut ce comportement.
+    public static let multimodalEncoderPrefixes: [String] = [
+        "vision_embedder",
+        "embed_vision",
+        "embed_audio",
+        "vision_tower",      // E2B/E4B SigLIP
+        "audio_tower",       // E2B/E4B Conformer
+    ]
+
+    /// Cherche `Module` sur le `LanguageModel` exposed via le protocol.
+    /// Tous nos modeles concrets (Gemma4LLMModel, *Multimodal*) sont des `Module`.
+    /// - Returns: nil si le cast echoue.
+    public static func asModule(_ model: LanguageModel) -> Module? {
+        return model as? Module
+    }
+
+    /// Applique la quantification a la volee sur `model`.
+    /// - Parameters:
+    ///   - model : `LanguageModel` du `ModelContext` (cast vers Module en interne).
+    ///   - bits  : 2, 3, 4, 6 ou 8 (selon le mode).
+    ///   - groupSize : taille des groupes (defaut 64).
+    ///   - mode : affine | mxfp4 | mxfp8.
+    ///   - excludedPathPrefixes : paths qui ne sont PAS quantifies (par defaut on saute les encoders multimodaux).
+    /// - Returns: nombre de modules quantifies.
+    @discardableResult
+    public static func apply(
+        to model: LanguageModel,
+        bits: Int,
+        groupSize: Int = 64,
+        mode: Mode = .affine,
+        excludedPathPrefixes: [String] = defaultExcludedPathPrefixes
+    ) -> Int {
+        guard let module = asModule(model) else {
+            print("[OnTheFlyQuantization] modele non-Module, skip")
+            return 0
+        }
+
+        // mxfp4/mxfp8 imposent group_size=32 cote MLX. On corrige silencieusement.
+        var effectiveGroupSize = groupSize
+        switch mode {
+        case .mxfp4, .mxfp8:
+            if effectiveGroupSize != 32 {
+                print("[OnTheFlyQuantization] \(mode.rawValue) requiert group_size=32, override")
+                effectiveGroupSize = 32
+            }
+        case .affine:
+            break
+        }
+
+        var quantizedCount = 0
+        let mlxMode = mode.mlxMode
+
+        // Filter prend (path, Module) -> tuple? : retourne le tuple pour quantizer, nil pour skip.
+        MLXNN.quantize(
+            model: module,
+            filter: { path, m -> (groupSize: Int, bits: Int, mode: QuantizationMode)? in
+                // Skip modules exclus
+                for prefix in excludedPathPrefixes {
+                    if path.hasPrefix(prefix) || path.contains(".\(prefix).") {
+                        return nil
+                    }
+                }
+                // Quantize Linear + Embedding seulement (defaut MLX)
+                if m is Linear || m is Embedding {
+                    return (groupSize: effectiveGroupSize, bits: bits, mode: mlxMode)
+                }
+                return nil
+            },
+            apply: { layer, gs, b, qmode in
+                quantizedCount += 1
+                return quantizeSingle(layer: layer, groupSize: gs, bits: b, mode: qmode)
+            }
+        )
+
+        // Materialiser les nouveaux poids quantifies pour que la 1ere inference
+        // ne paye pas le cout.
+        eval(module)
+
+        return quantizedCount
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4Pipeline.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4Pipeline.swift
@@ -41,9 +41,17 @@ public final class Gemma4Pipeline: @unchecked Sendable {
         case a4b6bit = "mlx-community/gemma-4-26b-a4b-it-6bit"
         case a4bBf16 = "mlx-community/gemma-4-26b-a4b-it-bf16"
 
+        // 12B Unified — 12B dense, MQA full attention (num_global_kv_heads=1),
+        // pas de KV-sharing ni per-layer-input. Multimodal vision/audio schema
+        // different (todo). Pour l'instant : text-only.
+        case b12b4bit = "mlx-community/gemma-4-12B-it-4bit"
+        case b12b6bit = "mlx-community/gemma-4-12B-it-6bit"
+        case b12b8bit = "mlx-community/gemma-4-12B-it-8bit"
+        case b12bBf16 = "mlx-community/gemma-4-12B-it-bf16"
+
         /// Famille du modele
         public enum Family: String, Sendable {
-            case e2b, e4b, b31b, a4b
+            case e2b, e4b, b31b, a4b, b12b
         }
 
         public var family: Family {
@@ -52,22 +60,24 @@ public final class Gemma4Pipeline: @unchecked Sendable {
             case .e4b4bit, .e4b8bit, .e4b6bit, .e4bBf16: return .e4b
             case .b31b4bit, .b31b8bit, .b31b6bit, .b31bBf16: return .b31b
             case .a4b4bit, .a4b8bit, .a4b6bit, .a4bBf16: return .a4b
+            case .b12b4bit, .b12b8bit, .b12b6bit, .b12bBf16: return .b12b
             }
         }
 
         public var displayName: String {
             let quant: String
             switch self {
-            case .e2b4bit, .e4b4bit, .b31b4bit, .a4b4bit: quant = "4-bit"
-            case .e2b8bit, .e4b8bit, .b31b8bit, .a4b8bit: quant = "8-bit"
-            case .e2b6bit, .e4b6bit, .b31b6bit, .a4b6bit: quant = "6-bit"
-            case .e2bBf16, .e4bBf16, .b31bBf16, .a4bBf16: quant = "BF16"
+            case .e2b4bit, .e4b4bit, .b31b4bit, .a4b4bit, .b12b4bit: quant = "4-bit"
+            case .e2b8bit, .e4b8bit, .b31b8bit, .a4b8bit, .b12b8bit: quant = "8-bit"
+            case .e2b6bit, .e4b6bit, .b31b6bit, .a4b6bit, .b12b6bit: quant = "6-bit"
+            case .e2bBf16, .e4bBf16, .b31bBf16, .a4bBf16, .b12bBf16: quant = "BF16"
             }
             switch family {
             case .e2b: return "Gemma 4 E2B (\(quant))"
             case .e4b: return "Gemma 4 E4B (\(quant))"
             case .b31b: return "Gemma 4 31B (\(quant))"
             case .a4b: return "Gemma 4 26B-A4B (\(quant))"
+            case .b12b: return "Gemma 4 12B Unified (\(quant))"
             }
         }
 
@@ -89,6 +99,10 @@ public final class Gemma4Pipeline: @unchecked Sendable {
             case .a4b6bit: return 21.0
             case .a4b8bit: return 27.0
             case .a4bBf16: return 52.0
+            case .b12b4bit: return 6.8
+            case .b12b6bit: return 9.5
+            case .b12b8bit: return 12.7
+            case .b12bBf16: return 24.0
             }
         }
 
@@ -99,6 +113,7 @@ public final class Gemma4Pipeline: @unchecked Sendable {
             case .e4b: return "9.6B"
             case .b31b: return "31.3B"
             case .a4b: return "25.8B"
+            case .b12b: return "12.0B"
             }
         }
 
@@ -109,6 +124,7 @@ public final class Gemma4Pipeline: @unchecked Sendable {
             case .e4b: return "4.5B"
             case .b31b: return "31.3B"
             case .a4b: return "3.8B"
+            case .b12b: return "12.0B"
             }
         }
 
@@ -117,10 +133,10 @@ public final class Gemma4Pipeline: @unchecked Sendable {
 
         public var quantization: String {
             switch self {
-            case .e2b4bit, .e4b4bit, .b31b4bit, .a4b4bit: return "4-bit"
-            case .e2b8bit, .e4b8bit, .b31b8bit, .a4b8bit: return "8-bit"
-            case .e2b6bit, .e4b6bit, .b31b6bit, .a4b6bit: return "6-bit"
-            case .e2bBf16, .e4bBf16, .b31bBf16, .a4bBf16: return "bf16"
+            case .e2b4bit, .e4b4bit, .b31b4bit, .a4b4bit, .b12b4bit: return "4-bit"
+            case .e2b8bit, .e4b8bit, .b31b8bit, .a4b8bit, .b12b8bit: return "8-bit"
+            case .e2b6bit, .e4b6bit, .b31b6bit, .a4b6bit, .b12b6bit: return "6-bit"
+            case .e2bBf16, .e4bBf16, .b31bBf16, .a4bBf16, .b12bBf16: return "bf16"
             }
         }
 
@@ -150,6 +166,9 @@ public final class Gemma4Pipeline: @unchecked Sendable {
             // 26B-A4B et 31B : text + image + video (pas d'audio)
             case .a4b, .b31b:
                 return .imageTextToText
+            // 12B Unified : text + image + video + audio (encoder-free design).
+            case .b12b:
+                return .anyToAny
             }
         }
 

--- a/Sources/Gemma4Swift/Pipeline/Gemma4Registration.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4Registration.swift
@@ -14,19 +14,41 @@ import MLXLLM
 /// ```
 public enum Gemma4Registration {
 
-    /// Enregistre les types "gemma4_text" et "gemma4" dans LLMTypeRegistry.shared
+    /// Enregistre les types "gemma4_text", "gemma4", "gemma4_unified_text" et
+    /// "gemma4_unified" dans LLMTypeRegistry.shared.
+    ///
+    /// `gemma4_unified*` correspond a la variante 12B (gemma-4-12B-it) qui
+    /// reutilise la meme architecture decoder. Le path text-only est
+    /// supporte out-of-the-box ; le path multimodal du 12B n'est pas encore
+    /// branche (schema vision/audio different) et tombe en text-only.
     /// - Parameter multimodal: si true, charge le modele multimodal complet (vision+audio)
+    ///   uniquement pour les variantes E2B/E4B (`gemma4`).
     public static func register(multimodal: Bool = false) async {
-        await LLMTypeRegistry.shared.registerModelType("gemma4_text") { configData in
+        let textFactory: @Sendable (Data) throws -> any LanguageModel = { configData in
             let fullConfig = try JSONDecoder().decode(Gemma4Config.self, from: configData)
             return Gemma4LLMModel(config: fullConfig.textConfig)
         }
+
+        await LLMTypeRegistry.shared.registerModelType("gemma4_text", creator: textFactory)
+        await LLMTypeRegistry.shared.registerModelType("gemma4_unified_text", creator: textFactory)
 
         await LLMTypeRegistry.shared.registerModelType("gemma4") { configData in
             let fullConfig = try JSONDecoder().decode(Gemma4Config.self, from: configData)
             if multimodal {
                 return Gemma4MultimodalLLMModel(config: fullConfig)
             } else {
+                return Gemma4LLMModel(config: fullConfig.textConfig)
+            }
+        }
+
+        // gemma4_unified : utilise le wrapper multimodal dedie en mode multimodal,
+        // sinon path text-only.
+        await LLMTypeRegistry.shared.registerModelType("gemma4_unified") { configData in
+            if multimodal {
+                let unifiedConfig = try JSONDecoder().decode(Gemma4UnifiedConfig.self, from: configData)
+                return Gemma4UnifiedMultimodalLLMModel(config: unifiedConfig)
+            } else {
+                let fullConfig = try JSONDecoder().decode(Gemma4Config.self, from: configData)
                 return Gemma4LLMModel(config: fullConfig.textConfig)
             }
         }

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedAudioProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedAudioProcessor.swift
@@ -1,0 +1,62 @@
+// Audio preprocessor pour gemma4_unified (12B).
+//
+// Difference avec [[Gemma4AudioProcessor]] (E2B/E4B mel-spectrogram + Conformer) :
+// le 12B prend des chunks PCM bruts (audioSamplesPerToken = 640 samples a 16kHz
+// = 40ms par token). Pas de mel, pas de Conformer.
+
+import AVFoundation
+import Foundation
+import MLX
+
+public enum Gemma4UnifiedAudioProcessor {
+
+    public struct ProcessedAudio: @unchecked Sendable {
+        /// [1, T, audioSamplesPerToken] = chunks PCM bruts.
+        public let features: MLXArray
+        /// [1, T] mask : true pour chunks valides, false pour padding.
+        public let mask: MLXArray
+        /// Nombre de tokens audio (= chunks valides).
+        public let numTokens: Int
+        public let durationSeconds: Float
+    }
+
+    /// Sample rate fixe (16kHz, comme E2B/E4B).
+    public static let sampleRate = 16_000
+
+    /// Pipeline : URL audio -> chunks PCM prets pour embed_audio.
+    /// - Parameters:
+    ///   - url : fichier audio (n'importe quel format AVFoundation).
+    ///   - config : audio_config du modele (samples_per_token = 640 typique).
+    ///   - maxDurationSeconds : tronquage de securite (30s par defaut).
+    public static func processAudio(
+        url: URL,
+        config: Gemma4UnifiedAudioConfig,
+        maxDurationSeconds: Float = 30.0
+    ) async throws -> ProcessedAudio {
+        var pcm = try await Gemma4AudioProcessor.loadAudioPCM(url: url)
+
+        let maxSamples = Int(maxDurationSeconds * Float(sampleRate))
+        if pcm.count > maxSamples {
+            pcm = Array(pcm.prefix(maxSamples))
+        }
+        let usedDuration = Float(pcm.count) / Float(sampleRate)
+
+        let samplesPerToken = config.audioSamplesPerToken
+        // Pad to multiple of samplesPerToken (constant 0, comme le Python).
+        let padLen = (samplesPerToken - (pcm.count % samplesPerToken)) % samplesPerToken
+        if padLen > 0 {
+            pcm.append(contentsOf: [Float](repeating: 0, count: padLen))
+        }
+
+        let numTokens = pcm.count / samplesPerToken
+        let features = MLXArray(pcm).reshaped(1, numTokens, samplesPerToken)
+        let mask = MLXArray.ones([1, numTokens], type: Bool.self)
+
+        return ProcessedAudio(
+            features: features,
+            mask: mask,
+            numTokens: numTokens,
+            durationSeconds: usedDuration
+        )
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedImageProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedImageProcessor.swift
@@ -1,0 +1,177 @@
+// Image preprocessor pour gemma4_unified (12B) — patches 48x48 sans encoder.
+//
+// Difference avec [[Gemma4ImageProcessor]] (E2B/E4B SigLIP) :
+//   - Sortie : (pixelValues [N, patchDim], positionIds [N, 2])
+//   - patchDim = modelPatchSize * modelPatchSize * 3 (par defaut 48*48*3 = 6912)
+//   - Pas de [1, C, H, W] : les patches sont directement flattenes.
+//   - Position IDs (x, y) pour chaque patch, -1 si padding.
+
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+import CoreGraphics
+import Foundation
+import MLX
+
+public enum Gemma4UnifiedImageProcessor {
+
+    /// Resultat du preprocessing d'une seule image.
+    public struct ProcessedImage: @unchecked Sendable {
+        /// [numPatches, patchDim] avec patchDim = modelPatchSize^2 * 3
+        public let patches: MLXArray
+        /// [numPatches, 2] = (x_idx, y_idx). -1 = padding.
+        public let positionIds: MLXArray
+        /// Nombre de patches valides (avant padding).
+        public let validPatches: Int
+    }
+
+    /// Pas de normalisation pour gemma4_unified (verifie processor_config.json :
+    /// do_normalize=false, image_mean=[0,0,0], image_std=[1,1,1]).
+    /// Seul le rescale 1/255 vers [0,1] est applique.
+    public static let imageMean: [Float] = [0.0, 0.0, 0.0]
+    public static let imageStd: [Float] = [1.0, 1.0, 1.0]
+
+    /// Pipeline complet : URL -> patches + positions ready for VisionEmbedder.
+    public static func processImage(
+        url: URL,
+        config: Gemma4UnifiedVisionConfig
+    ) throws -> ProcessedImage {
+        #if canImport(AppKit)
+        guard let nsImage = NSImage(contentsOf: url),
+              let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw ImageProcessingError.cannotLoadImage(url.path)
+        }
+        #elseif canImport(UIKit)
+        guard let data = try? Data(contentsOf: url),
+              let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else {
+            throw ImageProcessingError.cannotLoadImage(url.path)
+        }
+        #endif
+
+        return try processImage(cgImage, config: config)
+    }
+
+    /// Pipeline complet a partir d'un CGImage.
+    public static func processImage(
+        _ image: CGImage,
+        config: Gemma4UnifiedVisionConfig
+    ) throws -> ProcessedImage {
+        let modelPatch = config.modelPatchSize       // 48 = pooling_kernel * patch_size
+        let patchSize = config.patchSize             // 16
+        let maxPatches = config.maxPatches            // 280*9 = 2520 (en patches de patch_size)
+
+        // 1) aspect_ratio_preserving_resize (port verbatim du Python).
+        //    target_px (a patch_size=16) bornne ; on aligne ensuite sur modelPatch.
+        let origW = image.width
+        let origH = image.height
+
+        let targetPx = Float(maxPatches * patchSize * patchSize)
+        let factor = (targetPx / Float(origH * origW)).squareRoot()
+        let sideMult = modelPatch  // = pooling_kernel * patch_size
+
+        var bestH = Int(floor(factor * Float(origH) / Float(sideMult))) * sideMult
+        var bestW = Int(floor(factor * Float(origW) / Float(sideMult))) * sideMult
+
+        // Fallbacks (image extreme).
+        let maxSideLength = (maxPatches / (config.poolingKernelSize * config.poolingKernelSize)) * sideMult
+        if bestH == 0 && bestW == 0 {
+            // Image trop petite : on prend une seule cellule.
+            bestH = sideMult
+            bestW = sideMult
+        } else if bestH == 0 {
+            bestH = sideMult
+            bestW = min(Int(floor(Float(origW) / Float(origH))) * sideMult, maxSideLength)
+        } else if bestW == 0 {
+            bestW = sideMult
+            bestH = min(Int(floor(Float(origH) / Float(origW))) * sideMult, maxSideLength)
+        }
+
+        // 2) Redimensionner via CG (BGRA -> RGB float).
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel * bestW
+        var pixelData = [UInt8](repeating: 0, count: bestH * bytesPerRow)
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: &pixelData,
+            width: bestW, height: bestH,
+            bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        ) else {
+            throw ImageProcessingError.processingFailed
+        }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: bestW, height: bestH))
+
+        // 3) Normaliser en float32 [-1, 1] (mean=0.5, std=0.5).
+        // Layout du buffer : (H, W, 4=BGRA). On veut (3, H, W) channel-first.
+        let totalPixels = bestH * bestW
+        var rChannel = [Float](repeating: 0, count: totalPixels)
+        var gChannel = [Float](repeating: 0, count: totalPixels)
+        var bChannel = [Float](repeating: 0, count: totalPixels)
+        for i in 0 ..< totalPixels {
+            // CGContext avec noneSkipLast est en BGR ordering sur certaines plateformes ;
+            // mais avec CGColorSpaceCreateDeviceRGB + alphaInfo = noneSkipLast = RGBX.
+            rChannel[i] = (Float(pixelData[i * 4    ]) / 255.0 - imageMean[0]) / imageStd[0]
+            gChannel[i] = (Float(pixelData[i * 4 + 1]) / 255.0 - imageMean[1]) / imageStd[1]
+            bChannel[i] = (Float(pixelData[i * 4 + 2]) / 255.0 - imageMean[2]) / imageStd[2]
+        }
+
+        // 4) Decouper en patches (modelPatch x modelPatch x 3) flattenes.
+        let pH = bestH / modelPatch
+        let pW = bestW / modelPatch
+        let patchDim = config.patchDim
+        let numPatches = pH * pW
+
+        var patchesArr = [Float](repeating: 0, count: numPatches * patchDim)
+        var positionsArr = [Int32](repeating: 0, count: numPatches * 2)
+
+        for py in 0 ..< pH {
+            for px in 0 ..< pW {
+                let patchIdx = py * pW + px
+                positionsArr[patchIdx * 2    ] = Int32(px) // x
+                positionsArr[patchIdx * 2 + 1] = Int32(py) // y
+
+                // Copier le patch (modelPatch lignes x modelPatch cols x 3 canaux).
+                // Layout cible : (patchH, patchW, C) ligne-par-ligne.
+                let baseY = py * modelPatch
+                let baseX = px * modelPatch
+                let patchOffset = patchIdx * patchDim
+                for ly in 0 ..< modelPatch {
+                    let srcY = baseY + ly
+                    let rowSrcBase = srcY * bestW
+                    let rowDstBase = patchOffset + ly * modelPatch * 3
+                    for lx in 0 ..< modelPatch {
+                        let srcIdx = rowSrcBase + baseX + lx
+                        let dstIdx = rowDstBase + lx * 3
+                        patchesArr[dstIdx    ] = rChannel[srcIdx]
+                        patchesArr[dstIdx + 1] = gChannel[srcIdx]
+                        patchesArr[dstIdx + 2] = bChannel[srcIdx]
+                    }
+                }
+            }
+        }
+
+        // 5) Pad jusqu'a maxPatches (positions -1 pour les paddings).
+        let validCount = numPatches
+        let padTarget = maxPatches
+        var finalPatches = patchesArr
+        var finalPositions = positionsArr
+        if validCount < padTarget {
+            finalPatches.append(contentsOf: [Float](repeating: 0, count: (padTarget - validCount) * patchDim))
+            for _ in validCount ..< padTarget {
+                finalPositions.append(-1)
+                finalPositions.append(-1)
+            }
+        }
+
+        let patchesMLX = MLXArray(finalPatches).reshaped(padTarget, patchDim)
+        let positionsMLX = MLXArray(finalPositions).reshaped(padTarget, 2)
+
+        return ProcessedImage(patches: patchesMLX, positionIds: positionsMLX, validPatches: validCount)
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedImageProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedImageProcessor.swift
@@ -38,19 +38,7 @@ public enum Gemma4UnifiedImageProcessor {
         url: URL,
         config: Gemma4UnifiedVisionConfig
     ) throws -> ProcessedImage {
-        #if canImport(AppKit)
-        guard let nsImage = NSImage(contentsOf: url),
-              let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            throw ImageProcessingError.cannotLoadImage(url.path)
-        }
-        #elseif canImport(UIKit)
-        guard let data = try? Data(contentsOf: url),
-              let uiImage = UIImage(data: data),
-              let cgImage = uiImage.cgImage else {
-            throw ImageProcessingError.cannotLoadImage(url.path)
-        }
-        #endif
-
+        let cgImage = try Gemma4CGImageLoader.load(from: url)
         return try processImage(cgImage, config: config)
     }
 
@@ -107,70 +95,51 @@ public enum Gemma4UnifiedImageProcessor {
         context.interpolationQuality = .high
         context.draw(image, in: CGRect(x: 0, y: 0, width: bestW, height: bestH))
 
-        // 3) Normaliser en float32 [-1, 1] (mean=0.5, std=0.5).
-        // Layout du buffer : (H, W, 4=BGRA). On veut (3, H, W) channel-first.
-        let totalPixels = bestH * bestW
-        var rChannel = [Float](repeating: 0, count: totalPixels)
-        var gChannel = [Float](repeating: 0, count: totalPixels)
-        var bChannel = [Float](repeating: 0, count: totalPixels)
-        for i in 0 ..< totalPixels {
-            // CGContext avec noneSkipLast est en BGR ordering sur certaines plateformes ;
-            // mais avec CGColorSpaceCreateDeviceRGB + alphaInfo = noneSkipLast = RGBX.
-            rChannel[i] = (Float(pixelData[i * 4    ]) / 255.0 - imageMean[0]) / imageStd[0]
-            gChannel[i] = (Float(pixelData[i * 4 + 1]) / 255.0 - imageMean[1]) / imageStd[1]
-            bChannel[i] = (Float(pixelData[i * 4 + 2]) / 255.0 - imageMean[2]) / imageStd[2]
-        }
-
-        // 4) Decouper en patches (modelPatch x modelPatch x 3) flattenes.
+        // 3-4) Tout le pipeline RGBA -> normaliser -> patches en operations MLX
+        // vectorisees. Pour une image 2K (~4M pixels), on passe de ~16M
+        // operations scalaires Swift a quelques kernels MLX (gain ~10-50x).
         let pH = bestH / modelPatch
         let pW = bestW / modelPatch
         let patchDim = config.patchDim
         let numPatches = pH * pW
 
-        var patchesArr = [Float](repeating: 0, count: numPatches * patchDim)
-        var positionsArr = [Int32](repeating: 0, count: numPatches * 2)
+        // (a) buffer brut UInt8 [H*W*4] -> [H, W, 4] -> [H, W, 3] (drop alpha)
+        let raw = MLXArray(pixelData).reshaped(bestH, bestW, 4)
+        let rgb = raw[0..., 0..., 0..<3].asType(.float32) / MLXArray(Float(255.0))
 
-        for py in 0 ..< pH {
-            for px in 0 ..< pW {
-                let patchIdx = py * pW + px
-                positionsArr[patchIdx * 2    ] = Int32(px) // x
-                positionsArr[patchIdx * 2 + 1] = Int32(py) // y
+        // (b) normalisation par canal : (x - mean) / std (broadcast sur [3])
+        let mean = MLXArray(Self.imageMean)
+        let std = MLXArray(Self.imageStd)
+        let normalized = (rgb - mean) / std
 
-                // Copier le patch (modelPatch lignes x modelPatch cols x 3 canaux).
-                // Layout cible : (patchH, patchW, C) ligne-par-ligne.
-                let baseY = py * modelPatch
-                let baseX = px * modelPatch
-                let patchOffset = patchIdx * patchDim
-                for ly in 0 ..< modelPatch {
-                    let srcY = baseY + ly
-                    let rowSrcBase = srcY * bestW
-                    let rowDstBase = patchOffset + ly * modelPatch * 3
-                    for lx in 0 ..< modelPatch {
-                        let srcIdx = rowSrcBase + baseX + lx
-                        let dstIdx = rowDstBase + lx * 3
-                        patchesArr[dstIdx    ] = rChannel[srcIdx]
-                        patchesArr[dstIdx + 1] = gChannel[srcIdx]
-                        patchesArr[dstIdx + 2] = bChannel[srcIdx]
-                    }
-                }
-            }
-        }
+        // (c) decoupage en patches : [pH, mp, pW, mp, 3] -> [pH, pW, mp, mp, 3]
+        //     -> [numPatches, patchDim]
+        let patchesValid = normalized
+            .reshaped(pH, modelPatch, pW, modelPatch, 3)
+            .transposed(0, 2, 1, 3, 4)
+            .reshaped(numPatches, patchDim)
 
         // 5) Pad jusqu'a maxPatches (positions -1 pour les paddings).
         let validCount = numPatches
         let padTarget = maxPatches
-        var finalPatches = patchesArr
-        var finalPositions = positionsArr
+        let patchesMLX: MLXArray
         if validCount < padTarget {
-            finalPatches.append(contentsOf: [Float](repeating: 0, count: (padTarget - validCount) * patchDim))
-            for _ in validCount ..< padTarget {
-                finalPositions.append(-1)
-                finalPositions.append(-1)
-            }
+            let padding = MLXArray.zeros([padTarget - validCount, patchDim], type: Float.self)
+            patchesMLX = concatenated([patchesValid, padding], axis: 0)
+        } else {
+            patchesMLX = patchesValid
         }
 
-        let patchesMLX = MLXArray(finalPatches).reshaped(padTarget, patchDim)
-        let positionsMLX = MLXArray(finalPositions).reshaped(padTarget, 2)
+        // Positions (x, y) : petit tableau, on garde en Swift (numPatches <= 2520).
+        var positionsArr = [Int32](repeating: -1, count: padTarget * 2)
+        for py in 0 ..< pH {
+            for px in 0 ..< pW {
+                let patchIdx = py * pW + px
+                positionsArr[patchIdx * 2    ] = Int32(px)
+                positionsArr[patchIdx * 2 + 1] = Int32(py)
+            }
+        }
+        let positionsMLX = MLXArray(positionsArr).reshaped(padTarget, 2)
 
         return ProcessedImage(patches: patchesMLX, positionIds: positionsMLX, validPatches: validCount)
     }

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedMultimodalLLMModel.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedMultimodalLLMModel.swift
@@ -102,6 +102,30 @@ public class Gemma4UnifiedMultimodalLLMModel: Module, LLMModel, LoRAModel {
         )
     }
 
+    /// Variante de `callAsFunction` qui retourne logits + hidden states (pre-norm) +
+    /// intermediates K/V — utilise par le path MTP speculative decoding.
+    /// Symetrique a Gemma4MultimodalLLMModel.forwardWithIntermediates pour les
+    /// futurs drafters publiables sur 12B Unified.
+    public func forwardWithIntermediates(
+        _ inputs: MLXArray,
+        cache: [KVCache]?
+    ) -> LanguageForwardOutput {
+        let cacheArray: [KVCache?]? = cache?.map { $0 as KVCache? }
+        let visionMask: MLXArray? = computeVisionTokenMask(inputs)
+        if let inputsEmbeds = prepareMultimodalEmbeds(inputs) {
+            return languageModel.forwardWithIntermediates(
+                inputsEmbeds: inputsEmbeds,
+                cache: cacheArray,
+                visionTokenMask: visionMask
+            )
+        }
+        return languageModel.forwardWithIntermediates(
+            inputs: inputs,
+            cache: cacheArray,
+            visionTokenMask: visionMask
+        )
+    }
+
     /// Calcule un mask [B, T] bool : true ou le token est image OU video.
     /// Retourne nil si T==1 (decodage), ou si AUCUN token vision ni AUCUN audio
     /// (path text pur, pas de masking custom necessaire).

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedMultimodalLLMModel.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedMultimodalLLMModel.swift
@@ -213,9 +213,12 @@ public class Gemma4UnifiedMultimodalLLMModel: Module, LLMModel, LoRAModel {
             projected = stopGradient(projected)
             projected = projected.asType(inputsEmbeds.dtype)
 
-            // Compacter via mask (true = valide).
+            // Compacter via mask (true = valide). Clamping defensif au cas ou
+            // le mask aurait plus de samples valides que la projection (shape
+            // mismatch silencieux).
             if let mask = pendingAudioMask {
-                let validCount = mask.asType(.int32).sum().item(Int.self)
+                let rawCount = mask.asType(.int32).sum().item(Int.self)
+                let validCount = min(rawCount, projected.dim(1))
                 if validCount < projected.dim(1) {
                     projected = projected[0..., 0 ..< validCount]
                 }

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedMultimodalLLMModel.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedMultimodalLLMModel.swift
@@ -1,0 +1,260 @@
+// Modele multimodal gemma4_unified (12B) : language_model + vision_embedder + embed_vision + embed_audio.
+//
+// Difference avec [[Gemma4MultimodalLLMModel]] (E2B/E4B) :
+//   - Pas de SigLIP : vision_embedder est un patch projector simple.
+//   - Pas de Conformer : embed_audio prend directement les chunks PCM bruts.
+//   - get_image_features : besoin de image_position_ids ; on slice les patches
+//     par "validPatches" avant le masked_scatter pour ne pas injecter du padding.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXLMCommon
+import MLXLLM
+
+/// Modele Gemma 4 Unified multimodal (texte + vision + audio).
+public class Gemma4UnifiedMultimodalLLMModel: Module, LLMModel, LoRAModel {
+    public let config: Gemma4UnifiedConfig
+
+    @ModuleInfo(key: "language_model") var languageModel: Gemma4LanguageModel
+    @ModuleInfo(key: "vision_embedder") var visionEmbedder: Gemma4UnifiedVisionEmbedder?
+    @ModuleInfo(key: "embed_vision") var embedVision: MultimodalEmbedder?
+    @ModuleInfo(key: "embed_audio") var embedAudio: MultimodalEmbedder?
+
+    public let modelType: String
+    public var kvHeads: [Int]
+
+    // --- Pending state injecte par le pipeline avant l'appel forward ---
+    /// [B, N_pad, patchDim] patches flatten (B = nombre d'images stackees).
+    public var pendingPixelPatches: MLXArray?
+    /// [B, N_pad, 2] position ids (x, y), -1 = padding.
+    public var pendingImagePositionIds: MLXArray?
+    /// Nombre de patches VALIDES par image (== imageTokenCount par image).
+    public var pendingValidPatches: [Int]?
+
+    /// [F, N_pad, patchDim] frames video stackees (F = num frames).
+    public var pendingVideoFramePatches: MLXArray?
+    /// [F, N_pad, 2] position ids.
+    public var pendingVideoFramePositionIds: MLXArray?
+    /// Nombre de patches valides par frame.
+    public var pendingVideoValidPatches: [Int]?
+
+    /// [1, T, samplesPerToken] chunks PCM bruts.
+    public var pendingAudioFeatures: MLXArray?
+    /// [1, T] mask : true = valide, false = padding.
+    public var pendingAudioMask: MLXArray?
+
+    public init(config: Gemma4UnifiedConfig) {
+        self.config = config
+        self.modelType = config.modelType
+
+        let textConfig = config.textConfig
+        self._languageModel.wrappedValue = Gemma4LanguageModel(textConfig)
+        self.kvHeads = Array(repeating: textConfig.numKeyValueHeads, count: textConfig.numHiddenLayers)
+
+        // Vision (optionnelle)
+        if let visionConfig = config.visionConfig {
+            self._visionEmbedder.wrappedValue = Gemma4UnifiedVisionEmbedder(visionConfig)
+            self._embedVision.wrappedValue = MultimodalEmbedder(
+                embeddingDim: visionConfig.outputProjDims,
+                textHiddenSize: textConfig.hiddenSize,
+                eps: visionConfig.rmsNormEps
+            )
+        } else {
+            self._visionEmbedder.wrappedValue = nil
+            self._embedVision.wrappedValue = nil
+        }
+
+        // Audio (optionnelle)
+        if let audioConfig = config.audioConfig {
+            self._embedAudio.wrappedValue = MultimodalEmbedder(
+                embeddingDim: audioConfig.outputProjDims,
+                textHiddenSize: textConfig.hiddenSize,
+                eps: audioConfig.rmsNormEps
+            )
+        } else {
+            self._embedAudio.wrappedValue = nil
+        }
+
+        super.init()
+    }
+
+    // MARK: - LLMModel conformance
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let cacheArray: [KVCache?]? = cache?.map { $0 as KVCache? }
+        // visionTokenMask : pour bidirectional overlay sur les blocs vision (T > 1).
+        // Calcule TOUJOURS depuis inputs : meme apres prefill, le pattern image/video
+        // reste exact (pas d'audio dans le mask = comportement Python identique).
+        let visionMask: MLXArray? = computeVisionTokenMask(inputs)
+        if let inputsEmbeds = prepareMultimodalEmbeds(inputs) {
+            return languageModel(
+                inputsEmbeds: inputsEmbeds,
+                cache: cacheArray,
+                visionTokenMask: visionMask
+            )
+        }
+        return languageModel(
+            inputs: inputs,
+            cache: cacheArray,
+            visionTokenMask: visionMask
+        )
+    }
+
+    /// Calcule un mask [B, T] bool : true ou le token est image OU video.
+    /// Retourne nil si T==1 (decodage), ou si AUCUN token vision ni AUCUN audio
+    /// (path text pur, pas de masking custom necessaire).
+    ///
+    /// Note : Si la sequence contient des tokens audio, on retourne nil pour ne pas
+    /// appliquer l'overlay (cf. Python : "keep mixed image+audio prompts causal to
+    /// avoid the vision block overlay dominating quantized unified models").
+    private func computeVisionTokenMask(_ inputs: MLXArray) -> MLXArray? {
+        let shape = inputs.shape
+        let inputs2D = shape.count == 1 ? inputs.reshaped(1, -1) : inputs
+        let T = inputs2D.dim(1)
+        if T <= 1 { return nil }
+
+        let isImage = inputs2D .== Int32(config.imageTokenId)
+        let isVideo = inputs2D .== Int32(config.videoTokenId)
+        let isAudio = inputs2D .== Int32(config.audioTokenId)
+
+        let hasAudio = isAudio.asType(.int32).sum().item(Int.self) > 0
+        let hasVision = (isImage .|| isVideo).asType(.int32).sum().item(Int.self) > 0
+        if !hasVision || hasAudio { return nil }
+
+        return isImage .|| isVideo
+    }
+
+    /// Construit les embeddings fusionnes (vision + audio) si du media est en attente.
+    /// Retourne nil = mode text-only.
+    private func prepareMultimodalEmbeds(_ inputs: MLXArray) -> MLXArray? {
+        let hasImage = pendingPixelPatches != nil
+        let hasVideo = pendingVideoFramePatches != nil
+        let hasAudio = pendingAudioFeatures != nil
+        guard hasImage || hasVideo || hasAudio else { return nil }
+
+        var inputsEmbeds = languageModel.model.embedTokens(inputs)
+        inputsEmbeds = inputsEmbeds * MLXArray(languageModel.model.embedScale, dtype: .float32)
+
+        // --- Vision ---
+        if let patches = pendingPixelPatches,
+           let posIds = pendingImagePositionIds,
+           let embedder = visionEmbedder,
+           let proj = embedVision {
+            let numImages = patches.dim(0)
+            let valid = pendingValidPatches ?? Array(repeating: patches.dim(1), count: numImages)
+
+            // Embedder s'applique sur le tenseur complet (padding inclus, ignore via valid mask).
+            var features = embedder(patches, imagePositionIds: posIds) // [B, N_pad, mmEmbedDim]
+            features = proj(features)                                    // [B, N_pad, textHidden]
+            features = stopGradient(features)
+            features = features.asType(inputsEmbeds.dtype)
+
+            // Compacter : pour chaque image, garder uniquement valid[i] patches.
+            var compactedRows: [MLXArray] = []
+            for i in 0 ..< numImages {
+                let v = valid[i]
+                if v <= 0 { continue }
+                compactedRows.append(features[i, 0 ..< v]) // [v, D]
+            }
+            if !compactedRows.isEmpty {
+                let merged = concatenated(compactedRows, axis: 0) // [sum(v), D]
+                // [1, sum(v), D] pour scatter sur input batch=1.
+                let asBatch = expandedDimensions(merged, axis: 0)
+
+                let imageMask = inputs .== Int32(config.imageTokenId)
+                let imageMaskExp = broadcast(expandedDimensions(imageMask, axis: -1), to: inputsEmbeds.shape)
+                inputsEmbeds = maskedScatter(input: inputsEmbeds, mask: imageMaskExp, source: asBatch)
+            }
+
+            pendingPixelPatches = nil
+            pendingImagePositionIds = nil
+            pendingValidPatches = nil
+        }
+
+        // --- Video frames (meme embedder, scatter sur video_token_id) ---
+        if let patches = pendingVideoFramePatches,
+           let posIds = pendingVideoFramePositionIds,
+           let embedder = visionEmbedder,
+           let proj = embedVision {
+            let numFrames = patches.dim(0)
+            let valid = pendingVideoValidPatches ?? Array(repeating: patches.dim(1), count: numFrames)
+
+            var features = embedder(patches, imagePositionIds: posIds)
+            features = proj(features)
+            features = stopGradient(features)
+            features = features.asType(inputsEmbeds.dtype)
+
+            var compactedRows: [MLXArray] = []
+            for i in 0 ..< numFrames {
+                let v = valid[i]
+                if v <= 0 { continue }
+                compactedRows.append(features[i, 0 ..< v])
+            }
+            if !compactedRows.isEmpty {
+                let merged = concatenated(compactedRows, axis: 0)
+                let asBatch = expandedDimensions(merged, axis: 0)
+
+                let videoMask = inputs .== Int32(config.videoTokenId)
+                let videoMaskExp = broadcast(expandedDimensions(videoMask, axis: -1), to: inputsEmbeds.shape)
+                inputsEmbeds = maskedScatter(input: inputsEmbeds, mask: videoMaskExp, source: asBatch)
+            }
+
+            pendingVideoFramePatches = nil
+            pendingVideoFramePositionIds = nil
+            pendingVideoValidPatches = nil
+        }
+
+        // --- Audio ---
+        if let audioFeatures = pendingAudioFeatures,
+           let proj = embedAudio {
+            var projected = proj(audioFeatures) // [1, T, textHidden]
+            projected = stopGradient(projected)
+            projected = projected.asType(inputsEmbeds.dtype)
+
+            // Compacter via mask (true = valide).
+            if let mask = pendingAudioMask {
+                let validCount = mask.asType(.int32).sum().item(Int.self)
+                if validCount < projected.dim(1) {
+                    projected = projected[0..., 0 ..< validCount]
+                }
+            }
+
+            let audioMask = inputs .== Int32(config.audioTokenId)
+            let audioMaskExp = broadcast(expandedDimensions(audioMask, axis: -1), to: inputsEmbeds.shape)
+            inputsEmbeds = maskedScatter(input: inputsEmbeds, mask: audioMaskExp, source: projected)
+
+            pendingAudioFeatures = nil
+            pendingAudioMask = nil
+        }
+
+        return inputsEmbeds
+    }
+
+    public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
+        languageModel.makeCache()
+    }
+
+    public var loraLayers: [Module] {
+        languageModel.model.layers.map { $0 as Module }
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        WeightSanitizer.sanitize(
+            weights: weights,
+            hasVision: config.visionConfig != nil,
+            hasAudio: config.audioConfig != nil,
+            useClippedLinears: false
+        )
+    }
+
+    public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int? = nil) throws -> PrepareResult {
+        let promptTokens = input.text.tokens
+        guard promptTokens.shape[0] > 0 else {
+            let emptyToken = MLXArray(Int32(0))[0 ..< 0]
+            return .tokens(.init(tokens: emptyToken))
+        }
+        return .tokens(input.text)
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedVideoProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/Gemma4UnifiedVideoProcessor.swift
@@ -1,0 +1,119 @@
+// Video preprocessor pour gemma4_unified (12B).
+//
+// Strategie : echantillonner N frames a ~1 fps, traiter chaque frame comme une image
+// via [[Gemma4UnifiedImageProcessor]] avec un budget reduit de soft tokens
+// (vision_soft_tokens_per_video_frame, typiquement 70).
+
+import AVFoundation
+import CoreGraphics
+import Foundation
+import MLX
+
+public enum Gemma4UnifiedVideoProcessor {
+
+    public struct ProcessedVideoFrame: @unchecked Sendable {
+        public let patches: MLXArray      // [N_pad, patchDim]
+        public let positionIds: MLXArray  // [N_pad, 2]
+        public let validPatches: Int
+    }
+
+    public struct ProcessedVideo: @unchecked Sendable {
+        public let frames: [ProcessedVideoFrame]
+        public let timestamps: [Double]
+        public let sourceFPS: Float
+    }
+
+    public static let defaultMaxFrames = 32
+
+    /// Extrait des frames + les preprocesse au format patches.
+    /// - Parameters:
+    ///   - url : fichier video
+    ///   - config : vision_config du modele
+    ///   - softTokensPerFrame : budget de soft tokens par frame (defaut: 70).
+    ///     Override le `numSoftTokens` du config pour les videos (frames plus petites).
+    ///   - maxFrames : plafond du nombre de frames
+    public static func processVideo(
+        url: URL,
+        config: Gemma4UnifiedVisionConfig,
+        softTokensPerFrame: Int = 70,
+        maxFrames: Int = defaultMaxFrames
+    ) async throws -> ProcessedVideo {
+        let asset = AVAsset(url: url)
+        let duration = try await asset.load(.duration)
+        let durationSeconds = CMTimeGetSeconds(duration)
+
+        guard durationSeconds > 0 else {
+            throw VideoProcessingError.invalidVideo("Duree video invalide")
+        }
+
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        let sourceFPS: Float = (try? await tracks.first?.load(.nominalFrameRate)) ?? 24.0
+
+        let effectiveDuration = min(durationSeconds, Gemma4VideoProcessor.maxVideoDurationSeconds)
+        let frameCount = min(maxFrames, max(1, Int(effectiveDuration)))
+
+        var times: [CMTime] = []
+        var timestamps: [Double] = []
+        if frameCount == 1 {
+            let t = effectiveDuration / 2
+            times.append(CMTime(seconds: t, preferredTimescale: 600))
+            timestamps.append(t)
+        } else {
+            for i in 0 ..< frameCount {
+                let t = effectiveDuration * Double(i) / Double(frameCount - 1)
+                let clampedT = min(t, durationSeconds - 0.01)
+                times.append(CMTime(seconds: clampedT, preferredTimescale: 600))
+                timestamps.append(clampedT)
+            }
+        }
+
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.requestedTimeToleranceBefore = CMTime(seconds: 0.5, preferredTimescale: 600)
+        generator.requestedTimeToleranceAfter = CMTime(seconds: 0.5, preferredTimescale: 600)
+
+        // Reduit le budget de patches pour chaque frame (independent du config.numSoftTokens).
+        // On construit une config locale avec numSoftTokens=softTokensPerFrame pour
+        // que le processor d'image respecte ce budget.
+        let frameConfig = Self.makeFrameConfig(base: config, numSoftTokens: softTokensPerFrame)
+
+        var processed: [ProcessedVideoFrame] = []
+        for time in times {
+            let (cgImage, _) = try await generator.image(at: time)
+            let p = try Gemma4UnifiedImageProcessor.processImage(cgImage, config: frameConfig)
+            processed.append(ProcessedVideoFrame(
+                patches: p.patches,
+                positionIds: p.positionIds,
+                validPatches: p.validPatches
+            ))
+        }
+
+        return ProcessedVideo(
+            frames: processed,
+            timestamps: timestamps,
+            sourceFPS: sourceFPS
+        )
+    }
+
+    /// Construit une config derivee avec un budget de patches reduit (pour video).
+    private static func makeFrameConfig(
+        base: Gemma4UnifiedVisionConfig,
+        numSoftTokens: Int
+    ) -> Gemma4UnifiedVisionConfig {
+        // On encode en JSON puis re-decode pour reutiliser le decoder existant
+        // avec l'override de num_soft_tokens.
+        let json: [String: Any] = [
+            "model_type": base.modelType,
+            "model_patch_size": base.modelPatchSize,
+            "patch_size": base.patchSize,
+            "pooling_kernel_size": base.poolingKernelSize,
+            "mm_embed_dim": base.mmEmbedDim,
+            "mm_posemb_size": base.mmPosembSize,
+            "num_soft_tokens": numSoftTokens,
+            "output_proj_dims": base.outputProjDims,
+            "rms_norm_eps": base.rmsNormEps
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(Gemma4UnifiedVisionConfig.self, from: data)
+    }
+}

--- a/Sources/Gemma4Swift/Pipeline/ImageProcessor.swift
+++ b/Sources/Gemma4Swift/Pipeline/ImageProcessor.swift
@@ -25,19 +25,7 @@ public enum Gemma4ImageProcessor {
         patchSize: Int = 16,
         poolingKernelSize: Int = 3
     ) throws -> MLXArray {
-        #if canImport(AppKit)
-        guard let nsImage = NSImage(contentsOf: url),
-              let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            throw ImageProcessingError.cannotLoadImage(url.path)
-        }
-        #elseif canImport(UIKit)
-        guard let data = try? Data(contentsOf: url),
-              let uiImage = UIImage(data: data),
-              let cgImage = uiImage.cgImage else {
-            throw ImageProcessingError.cannotLoadImage(url.path)
-        }
-        #endif
-
+        let cgImage = try Gemma4CGImageLoader.load(from: url)
         return try processImage(cgImage, maxSoftTokens: maxSoftTokens, patchSize: patchSize, poolingKernelSize: poolingKernelSize)
     }
 

--- a/Sources/Gemma4Swift/RoPE/ProportionalRoPE.swift
+++ b/Sources/Gemma4Swift/RoPE/ProportionalRoPE.swift
@@ -1,17 +1,23 @@
-// Port de rope_utils.py ProportionalRoPE — RoPE avec rotation partielle pour full attention
+// Port de mlx-lm/models/rope_utils.py ProportionalRoPE (version optimisee).
+//
+// Astuce du code mlx-lm Python : au lieu de slicer/concatener x pour ne rotater
+// qu'une partie des dimensions, on padde le tableau de frequences avec des `inf`
+// pour les positions non rotees. `mx.fast.rope` interprete cos(t*inf)/sin(t*inf)
+// comme identite (cos -> 1, sin -> 0), ce qui laisse ces dimensions inchangees.
+//
+// Resultat : 1 seul appel MLXFast.RoPE au lieu de 6 slice/concat. Critique pour
+// le throughput sur 12B (8 full-attn layers x 2 (Q+K) par token).
 
 import MLX
 import MLXFast
 import MLXNN
 
 /// ProportionalRoPE pour les couches full_attention de Gemma 4.
-/// Applique la rotation seulement sur une fraction des dimensions du head (partial_rotary_factor).
-/// Les frequences sont calculees relativement a la dimension complete du head.
-/// N'herite PAS de Module car freqs n'est pas un parametre apprenable.
+/// Tient compte de `partial_rotary_factor` via le padding `inf` du tableau de
+/// frequences plutot que par slicing.
 public final class ProportionalRoPE {
     let dims: Int
     let traditional: Bool
-    let rotatedDims: Int
     let freqs: MLXArray?
 
     public init(
@@ -24,74 +30,39 @@ public final class ProportionalRoPE {
         self.dims = dims
         self.traditional = traditional
 
-        let ropeAngles = Int(partialRotaryFactor * Float(dims) / 2.0)
-        self.rotatedDims = 2 * ropeAngles
+        // rotated_dims aligne sur 2 (paires reelles/imaginaires).
+        let rotatedDims = 2 * Int(partialRotaryFactor * Float(dims) / 2.0)
 
         if rotatedDims > 0 {
+            let realCount = rotatedDims / 2
             let exponents = MLXArray(stride(from: Float(0), to: Float(rotatedDims), by: 2)) / Float(dims)
-            self.freqs = factor * pow(MLXArray(base), exponents)
+            let realFreqs = factor * pow(MLXArray(base), exponents)
+
+            let padCount = (dims - rotatedDims) / 2
+            if padCount > 0 {
+                // Pad avec +inf -> rotation identite sur les dimensions non rotees.
+                let pad = MLXArray(Array(repeating: Float.infinity, count: padCount))
+                self.freqs = concatenated([realFreqs, pad], axis: 0)
+            } else {
+                self.freqs = realFreqs
+            }
+            _ = realCount // (silenced unused; kept for readability above)
         } else {
             self.freqs = nil
         }
     }
 
     public func callAsFunction(_ x: MLXArray, offset: Int = 0) -> MLXArray {
-        guard rotatedDims > 0, let freqs = freqs else { return x }
+        guard let freqs = freqs else { return x }
 
-        let head = x[.ellipsis, 0 ..< dims]
-        let half = dims / 2
-
-        // Split en deux moities gauche/droite
-        let left = head[.ellipsis, 0 ..< half]
-        let right = head[.ellipsis, half ..< dims]
-
-        let rotHalf = rotatedDims / 2
-
-        // Extraire les portions a rotater de chaque moitie
-        let leftRot = left[.ellipsis, 0 ..< rotHalf]
-        let rightRot = right[.ellipsis, 0 ..< rotHalf]
-
-        // Concatener pour former le vecteur a rotater
-        let toRotate = concatenated([leftRot, rightRot], axis: -1)
-
-        // Appliquer RoPE via MLXFast
-        let rotated = MLXFast.RoPE(
-            toRotate,
-            dimensions: rotatedDims,
+        return MLXFast.RoPE(
+            x,
+            dimensions: dims,
             traditional: traditional,
             base: nil as Float?,
             scale: 1.0,
             offset: offset,
             freqs: freqs
         )
-
-        // Recombiner : gauche = [rotated_left, left_passthrough], droite = [rotated_right, right_passthrough]
-        let newLeft: MLXArray
-        if rotHalf < half {
-            let rotLeft = rotated[.ellipsis, 0 ..< rotHalf]
-            let passLeft = left[.ellipsis, rotHalf...]
-            newLeft = concatenated([rotLeft, passLeft], axis: -1)
-        } else {
-            newLeft = rotated[.ellipsis, 0 ..< rotHalf]
-        }
-
-        let newRight: MLXArray
-        if rotHalf < half {
-            let rotRight = rotated[.ellipsis, rotHalf...]
-            let passRight = right[.ellipsis, rotHalf...]
-            newRight = concatenated([rotRight, passRight], axis: -1)
-        } else {
-            newRight = rotated[.ellipsis, rotHalf...]
-        }
-
-        let newHead = concatenated([newLeft, newRight], axis: -1)
-
-        // Si le tensor original avait des dims au-dela de dims, les reattacher
-        if x.shape.last! > dims {
-            let tail = x[.ellipsis, dims...]
-            return concatenated([newHead, tail], axis: -1)
-        }
-
-        return newHead
     }
 }

--- a/Sources/Gemma4Swift/TextModel/Gemma4BidirectionalMask.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4BidirectionalMask.swift
@@ -1,0 +1,61 @@
+// Bidirectional attention overlay pour les blocs vision (gemma4_unified).
+//
+// Port du Python LanguageModel._block_sequence_ids_for_mask /
+// _apply_blockwise_bidirectional_overlay.
+//
+// Pour chaque bloc CONTIGU de tokens vision dans la sequence, on autorise
+// l'attention bidirectionnelle entre les positions de CE bloc. Le reste
+// (text-text, text-vision, vision-text vers le futur) reste causal.
+
+import Foundation
+import MLX
+
+public enum Gemma4BidirectionalMask {
+
+    /// Pour un mask [B, T] (true = token vision), retourne block_sequence_ids
+    /// [B, T] int32 : id de bloc pour chaque position vision, -1 pour text/audio.
+    ///
+    /// Exemple : visionMask = [0,0,1,1,1,0,0,1,1,0]
+    ///          block_ids  = [-1,-1,0,0,0,-1,-1,1,1,-1]
+    public static func blockSequenceIds(visionMask: MLXArray) -> MLXArray {
+        let isVision = visionMask
+        // prev[b, t] = isVision[b, t-1] (avec 0 prepended)
+        let B = isVision.dim(0)
+        let T = isVision.dim(1)
+        let zerosPrefix = MLXArray.zeros([B, 1], type: Bool.self)
+        let prev: MLXArray
+        if T <= 1 {
+            prev = zerosPrefix
+        } else {
+            prev = concatenated([zerosPrefix, isVision[0..., 0 ..< (T - 1)]], axis: 1)
+        }
+        // starts[b, t] = isVision[b, t] AND NOT prev[b, t]
+        let starts = isVision .&& logicalNot(prev)
+        // group_ids = cumsum(starts) - 1
+        let cumStarts = cumsum(starts.asType(.int32), axis: 1)
+        let groupIds = cumStarts - MLXArray(Int32(1))
+        // Pour les positions text : -1
+        let minusOne = MLXArray.zeros(like: groupIds) - MLXArray(Int32(1))
+        return MLX.where(isVision, groupIds, minusOne)
+    }
+
+    /// Construit l'overlay bidirectionnel a partir des block_sequence_ids.
+    /// Retourne un mask bool [B, T, T] : true ou les 2 positions sont dans LE MEME bloc vision.
+    public static func overlay(blockSequenceIds: MLXArray) -> MLXArray {
+        // qBlocks [B, T, 1], kBlocks [B, 1, T]
+        let qBlocks = expandedDimensions(blockSequenceIds, axis: -1)
+        let kBlocks = expandedDimensions(blockSequenceIds, axis: -2)
+        let notMinus = qBlocks .!= MLXArray(Int32(-1))
+        let sameBlock = (qBlocks .== kBlocks) .&& notMinus
+        return sameBlock
+    }
+
+    /// Compose un mask causal materialise (bool [T, T]) avec l'overlay bidirectionnel.
+    /// `causal` shape [T, T] bool. `overlayBT` shape [B, T, T] bool.
+    /// Retourne [B, T, T] bool (true = autorise).
+    public static func compose(causal: MLXArray, overlay overlayBT: MLXArray) -> MLXArray {
+        // Broadcast causal [T, T] -> [1, T, T] pour OR.
+        let causalB = expandedDimensions(causal, axis: 0)
+        return causalB .|| overlayBT
+    }
+}

--- a/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
@@ -36,13 +36,15 @@ public class Gemma4LanguageModel: Module {
         inputs: MLXArray? = nil,
         inputsEmbeds: MLXArray? = nil,
         cache: [KVCache?]? = nil,
-        perLayerInputs: MLXArray? = nil
+        perLayerInputs: MLXArray? = nil,
+        visionTokenMask: MLXArray? = nil
     ) -> MLXArray {
         var out = model(
             inputs: inputs,
             inputsEmbeds: inputsEmbeds,
             cache: cache,
-            perLayerInputs: perLayerInputs
+            perLayerInputs: perLayerInputs,
+            visionTokenMask: visionTokenMask
         )
 
         // Tied word embeddings: utiliser embed_tokens comme linear

--- a/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
@@ -65,13 +65,15 @@ public class Gemma4LanguageModel: Module {
         inputs: MLXArray? = nil,
         inputsEmbeds: MLXArray? = nil,
         cache: [KVCache?]? = nil,
-        perLayerInputs: MLXArray? = nil
+        perLayerInputs: MLXArray? = nil,
+        visionTokenMask: MLXArray? = nil
     ) -> LanguageForwardOutput {
         let textOut = model.forwardCollectingIntermediates(
             inputs: inputs,
             inputsEmbeds: inputsEmbeds,
             cache: cache,
-            perLayerInputs: perLayerInputs
+            perLayerInputs: perLayerInputs,
+            visionTokenMask: visionTokenMask
         )
 
         var logits = model.embedTokens.asLinear(textOut.hidden)

--- a/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4LanguageModel.swift
@@ -93,10 +93,31 @@ public class Gemma4LanguageModel: Module {
     /// nombre de couches full attention et la taille des KV heads sont
     /// suffisants pour que le gain de compression depasse l'overhead.
     public func turboQuantViable(bits: Float) -> (viable: Bool, fullAttnLayers: Int, kvHeadDim: Int, reason: String) {
+        Self.turboQuantViability(config: config, bits: bits)
+    }
+
+    /// Heuristique pure-fonction (testable sans MLX). Estime le gain RAM TurboQuant
+    /// a un contexte de reference (16K) et compare a l'overhead fixe estime.
+    ///
+    /// IMPORTANT — biais corrige : sur les modeles MQA full attention (ex: 12B
+    /// Unified avec `attention_k_eq_v=true` + `num_global_key_value_heads=1`),
+    /// les couches full_attention n'ont que 1 KV head et non `num_key_value_heads`.
+    /// Le gain TurboQuant est proportionnel au nombre de KV heads SUR full_attention,
+    /// donc utiliser `num_key_value_heads` (8 sur 12B) surestime massivement le
+    /// gain et active TQ alors qu'il est couteux en perf.
+    public static func turboQuantViability(
+        config: Gemma4TextConfig, bits: Float
+    ) -> (viable: Bool, fullAttnLayers: Int, kvHeadDim: Int, reason: String) {
         let layerTypes = config.resolvedLayerTypes
         let concreteLayers = Array(layerTypes[..<config.firstKvSharedLayerIdx])
         let fullAttnCount = concreteLayers.filter { $0 == "full_attention" }.count
-        let kvHeads = config.numKeyValueHeads
+
+        let fullAttnKvHeads: Int
+        if config.attentionKEqV, let globalKvH = config.numGlobalKeyValueHeads {
+            fullAttnKvHeads = globalKvH
+        } else {
+            fullAttnKvHeads = config.numKeyValueHeads
+        }
         let headDim = config.globalHeadDim > 0 ? config.globalHeadDim : config.headDim
 
         // Overhead fixe ~500 Mo process (graph MLX, codecs, rotation matrices)
@@ -106,8 +127,8 @@ public class Gemma4LanguageModel: Module {
         //   Rotation: D * D * 4 * 2 (key+value codecs)
         let T = 16000 // reference context
         let packedWidth = (headDim * Int(bits) + 31) / 32
-        let bf16PerLayer = T * headDim * kvHeads * 2 * 2
-        let tqPerLayer = T * (2 + packedWidth * 4) * kvHeads * 2
+        let bf16PerLayer = T * headDim * fullAttnKvHeads * 2 * 2
+        let tqPerLayer = T * (2 + packedWidth * 4) * fullAttnKvHeads * 2
         let rotPerLayer = headDim * headDim * 4 * 2
         let savingPerLayer = bf16PerLayer - tqPerLayer - rotPerLayer
         let totalSaving = savingPerLayer * fullAttnCount
@@ -117,9 +138,9 @@ public class Gemma4LanguageModel: Module {
             return (false, fullAttnCount, headDim, "trop peu de couches full attention (\(fullAttnCount))")
         }
         if totalSaving < overheadEstimate / 2 {
-            return (false, fullAttnCount, headDim, "gain estime \(totalSaving / 1024 / 1024) Mo < overhead ~500 Mo a 16K tokens")
+            return (false, fullAttnCount, headDim, "gain estime \(totalSaving / 1024 / 1024) Mo < overhead ~500 Mo a 16K tokens (full_attn kv_heads=\(fullAttnKvHeads))")
         }
-        return (true, fullAttnCount, headDim, "gain estime \(totalSaving / 1024 / 1024) Mo a 16K tokens sur \(fullAttnCount) couches")
+        return (true, fullAttnCount, headDim, "gain estime \(totalSaving / 1024 / 1024) Mo a 16K tokens sur \(fullAttnCount) couches (kv_heads=\(fullAttnKvHeads))")
     }
 
     /// Cree les caches KV pour chaque couche concrete (non-partagee)

--- a/Sources/Gemma4Swift/TextModel/Gemma4Router.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4Router.swift
@@ -5,6 +5,13 @@ import MLX
 import MLXNN
 
 /// Router MoE Gemma 4 : norm → scale → project → softmax → top-k → renormalize → per_expert_scale
+///
+/// NB : tentative de port verbatim de la version Python "softmax-sur-top-k" (au
+/// lieu de "softmax-sur-tout + renormalize sur top-k") a DEGRADE l'accuracy
+/// MMLU sur 26B-A4B (-3 pts). Garde la version "softmax-sur-tout + renormalize"
+/// qui empiriquement preserve mieux la qualite sur ce checkpoint. La cause exacte
+/// de la divergence vs Python reste a investiguer (probable interaction MoE +
+/// 4-bit quant + ordering numerique en bf16).
 public class Gemma4Router: Module {
     let numExperts: Int
     let topK: Int

--- a/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
@@ -177,107 +177,19 @@ public class Gemma4TextModel: Module {
         // collecte d'intermediates qui retient ~150 MB de K/V refs par forward
         // et augmente la pression memoire pendant le prefill.
         // Pour E2B/E4B (avec KV-sharing), on garde le path complet.
-        if firstKvSharedLayerIdx >= numHiddenLayers {
-            return forwardWithoutIntermediates(
-                inputs: inputs,
-                inputsEmbeds: inputsEmbeds,
-                cache: cache,
-                perLayerInputs: perLayerInputs,
-                visionTokenMask: visionTokenMask
-            )
+        let collect = firstKvSharedLayerIdx < numHiddenLayers
+        if collect {
+            return runForward(
+                inputs: inputs, inputsEmbeds: inputsEmbeds, cache: cache,
+                perLayerInputs: perLayerInputs, visionTokenMask: visionTokenMask,
+                collectIntermediates: true
+            ).hidden
         }
-        return forwardCollectingIntermediates(
-            inputs: inputs,
-            inputsEmbeds: inputsEmbeds,
-            cache: cache,
-            perLayerInputs: perLayerInputs,
-            visionTokenMask: visionTokenMask
+        return runForward(
+            inputs: inputs, inputsEmbeds: inputsEmbeds, cache: cache,
+            perLayerInputs: perLayerInputs, visionTokenMask: visionTokenMask,
+            collectIntermediates: false
         ).hidden
-    }
-
-    /// Forward optimise pour les modeles SANS KV-sharing.
-    /// Identique a forwardCollectingIntermediates() mais ne stocke pas les
-    /// K/V intermediaires (pas d'array `intermediates[]`, pas de
-    /// `publicIntermediates`, pas de struct TextForwardOutput a wrapper).
-    ///
-    /// Ne pas utiliser sur E2B/E4B (KV-sharing necessite les intermediates).
-    private func forwardWithoutIntermediates(
-        inputs: MLXArray? = nil,
-        inputsEmbeds: MLXArray? = nil,
-        cache: [KVCache?]? = nil,
-        perLayerInputs: MLXArray? = nil,
-        visionTokenMask: MLXArray? = nil
-    ) -> MLXArray {
-        var h: MLXArray
-        if let inputsEmbeds = inputsEmbeds {
-            h = inputsEmbeds
-        } else if let inputs = inputs {
-            h = embedTokens(inputs)
-            h = h * MLXArray(embedScale, dtype: h.dtype)
-        } else {
-            fatalError("inputs ou inputsEmbeds requis")
-        }
-
-        var finalPerLayerInputs: MLXArray? = nil
-        if hiddenSizePerLayerInput > 0 {
-            var pli = perLayerInputs
-            if inputs != nil && pli == nil {
-                pli = getPerLayerInputs(inputs!)
-            }
-            if pli != nil || inputs != nil {
-                finalPerLayerInputs = projectPerLayerInputs(h, perLayerInputs: pli)
-            }
-        }
-
-        let cacheArray = cache ?? Array(repeating: nil as KVCache?, count: firstKvSharedLayerIdx)
-
-        var globalMask = MLXLMCommon.createAttentionMask(
-            h: h,
-            cache: firstFullCacheIdx < cacheArray.count ? cacheArray[firstFullCacheIdx] : nil
-        )
-        var slidingWindowMask = MLXLMCommon.createAttentionMask(
-            h: h,
-            cache: firstSlidingCacheIdx < cacheArray.count ? cacheArray[firstSlidingCacheIdx] : nil,
-            windowSize: windowSize
-        )
-
-        let T = h.dim(1)
-        if let visionMask = visionTokenMask, T > 1 {
-            let blockIds = Gemma4BidirectionalMask.blockSequenceIds(visionMask: visionMask)
-            let overlay = Gemma4BidirectionalMask.overlay(blockSequenceIds: blockIds)
-            let causalGlobal = MLXLMCommon.createCausalMask(n: T, offset: 0)
-            let causalSliding = MLXLMCommon.createCausalMask(n: T, offset: 0, windowSize: windowSize)
-            let mergedGlobal = Gemma4BidirectionalMask.compose(causal: causalGlobal, overlay: overlay)
-            let mergedSliding = Gemma4BidirectionalMask.compose(causal: causalSliding, overlay: overlay)
-            globalMask = .array(mergedGlobal)
-            slidingWindowMask = .array(mergedSliding)
-        }
-
-        let layerTypes = config.resolvedLayerTypes
-
-        for (i, layer) in layers.enumerated() {
-            let cacheIdx = layerIdxToCacheIdx[i]
-            let c = cacheIdx < cacheArray.count ? cacheArray[cacheIdx] : nil
-            let isGlobal = layerTypes[i] == "full_attention"
-            let localMask = isGlobal ? globalMask : slidingWindowMask
-
-            let perLayerInput: MLXArray?
-            if let fpli = finalPerLayerInputs {
-                perLayerInput = fpli[0..., 0..., i, 0...]
-            } else {
-                perLayerInput = nil
-            }
-
-            // Pas de KV-sharing : on jette les K/V retournes par la couche
-            // (le cache les a deja stockes pour ses propres besoins).
-            let (output, _, _) = layer(
-                h, mask: localMask, cache: c, perLayerInput: perLayerInput,
-                sharedKV: nil, sharedOffset: nil
-            )
-            h = output
-        }
-
-        return norm(h)
     }
 
     /// Variante de `callAsFunction` qui retourne aussi les K/V intermediaires
@@ -294,6 +206,25 @@ public class Gemma4TextModel: Module {
         cache: [KVCache?]? = nil,
         perLayerInputs: MLXArray? = nil,
         visionTokenMask: MLXArray? = nil
+    ) -> TextForwardOutput {
+        runForward(
+            inputs: inputs, inputsEmbeds: inputsEmbeds, cache: cache,
+            perLayerInputs: perLayerInputs, visionTokenMask: visionTokenMask,
+            collectIntermediates: true
+        )
+    }
+
+    /// Path partage entre `callAsFunction` (fast-path sans intermediates) et
+    /// `forwardCollectingIntermediates` (avec intermediates pour KV-sharing /
+    /// MTP). La logique embedding, masks, layer loop et norm est identique ;
+    /// seul l'enregistrement des K/V dans un array `intermediates[]` differe.
+    private func runForward(
+        inputs: MLXArray?,
+        inputsEmbeds: MLXArray?,
+        cache: [KVCache?]?,
+        perLayerInputs: MLXArray?,
+        visionTokenMask: MLXArray?,
+        collectIntermediates: Bool
     ) -> TextForwardOutput {
         var h: MLXArray
         if let inputsEmbeds = inputsEmbeds {
@@ -350,12 +281,15 @@ public class Gemma4TextModel: Module {
             slidingWindowMask = .array(mergedSliding)
         }
 
-        // Forward a travers les layers — avec suivi des intermediaires pour le KV sharing
-        // Ref: Python mlx-lm gemma4_text.py utilise intermediates[] + previous_kvs
-        // pour passer les K/V des couches non-partagees aux couches partagees.
+        // Forward a travers les layers — avec ou sans suivi des intermediaires.
+        // Le suivi est necessaire pour le KV sharing (E2B/E4B) et pour MTP.
+        // Sans suivi : on jette les K/V retournes (~150 MB economises par
+        // forward sur prefill long, gain x2.3 mesure sur MMLU Pro CoT 12B).
         let layerTypes = config.resolvedLayerTypes
         var intermediates: [(kv: (keys: MLXArray, values: MLXArray), offset: Int)?] =
-            Array(repeating: nil, count: numHiddenLayers)
+            collectIntermediates
+                ? Array(repeating: nil, count: numHiddenLayers)
+                : []
 
         for (i, layer) in layers.enumerated() {
             let cacheIdx = layerIdxToCacheIdx[i]
@@ -372,10 +306,12 @@ public class Gemma4TextModel: Module {
             }
 
             // KV sharing: passer les K/V de la couche source aux couches partagees
-            // (seulement quand pas de cache — le cache gere deja le sharing a l'inference)
+            // (seulement quand pas de cache — le cache gere deja le sharing a l'inference).
+            // Quand collectIntermediates est false, on n'a pas de KV-sharing par definition.
             let sharedKV: (keys: MLXArray, values: MLXArray)?
             let sharedOffset: Int?
-            if i >= firstKvSharedLayerIdx && firstKvSharedLayerIdx > 0 && cache == nil,
+            if collectIntermediates,
+               i >= firstKvSharedLayerIdx && firstKvSharedLayerIdx > 0 && cache == nil,
                let prev = intermediates[cacheIdx] {
                 sharedKV = prev.kv
                 sharedOffset = prev.offset
@@ -384,22 +320,39 @@ public class Gemma4TextModel: Module {
                 sharedOffset = nil
             }
 
-            let (output, kv, offset) = layer(
-                h, mask: localMask, cache: c, perLayerInput: perLayerInput,
-                sharedKV: sharedKV, sharedOffset: sharedOffset
-            )
-            h = output
-            intermediates[i] = (kv: kv, offset: offset)
-        }
-
-        let publicIntermediates: [LayerIntermediate?] = intermediates.map { entry in
-            guard let entry = entry else { return nil }
-            return LayerIntermediate(keys: entry.kv.keys, values: entry.kv.values, offset: entry.offset)
+            if collectIntermediates {
+                let (output, kv, offset) = layer(
+                    h, mask: localMask, cache: c, perLayerInput: perLayerInput,
+                    sharedKV: sharedKV, sharedOffset: sharedOffset
+                )
+                h = output
+                intermediates[i] = (kv: kv, offset: offset)
+            } else {
+                // Fast path : on jette les K/V (le cache les a deja captures
+                // pour ses propres besoins).
+                let (output, _, _) = layer(
+                    h, mask: localMask, cache: c, perLayerInput: perLayerInput,
+                    sharedKV: nil, sharedOffset: nil
+                )
+                h = output
+            }
         }
 
         // Capture h pre-norm pour le drafter MTP, puis applique norm pour les logits standard.
         let preNormHidden = h
         let normedHidden = norm(h)
+
+        let publicIntermediates: [LayerIntermediate?]
+        if collectIntermediates {
+            publicIntermediates = intermediates.map { entry in
+                guard let entry = entry else { return nil }
+                return LayerIntermediate(
+                    keys: entry.kv.keys, values: entry.kv.values, offset: entry.offset
+                )
+            }
+        } else {
+            publicIntermediates = []
+        }
 
         return TextForwardOutput(
             hidden: normedHidden,

--- a/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
@@ -170,24 +170,32 @@ public class Gemma4TextModel: Module {
         inputs: MLXArray? = nil,
         inputsEmbeds: MLXArray? = nil,
         cache: [KVCache?]? = nil,
-        perLayerInputs: MLXArray? = nil
+        perLayerInputs: MLXArray? = nil,
+        visionTokenMask: MLXArray? = nil
     ) -> MLXArray {
         forwardCollectingIntermediates(
             inputs: inputs,
             inputsEmbeds: inputsEmbeds,
             cache: cache,
-            perLayerInputs: perLayerInputs
+            perLayerInputs: perLayerInputs,
+            visionTokenMask: visionTokenMask
         ).hidden
     }
 
     /// Variante de `callAsFunction` qui retourne aussi les K/V intermediaires
     /// par couche. Utilise par le path MTP pour exposer les K/V partages au drafter.
     /// Le `callAsFunction` standard reste inchange (delegate vers cette methode).
+    ///
+    /// - Parameter visionTokenMask : `[B, T]` bool, true ou le token est vision (image/video).
+    ///   Si fourni ET prefill (T > 1), active l'overlay bidirectionnel sur les blocs vision
+    ///   (port du Python `_apply_blockwise_bidirectional_overlay`). Utilise par
+    ///   [[Gemma4UnifiedMultimodalLLMModel]] quand `use_bidirectional_attention=vision`.
     public func forwardCollectingIntermediates(
         inputs: MLXArray? = nil,
         inputsEmbeds: MLXArray? = nil,
         cache: [KVCache?]? = nil,
-        perLayerInputs: MLXArray? = nil
+        perLayerInputs: MLXArray? = nil,
+        visionTokenMask: MLXArray? = nil
     ) -> TextForwardOutput {
         var h: MLXArray
         if let inputsEmbeds = inputsEmbeds {
@@ -217,15 +225,32 @@ public class Gemma4TextModel: Module {
         // Masques d'attention — utilise createAttentionMask() de MLXLMCommon
         // Pour les single tokens (T=1) : retourne .none (pas de masque materialise)
         // Pour les multi-tokens (prefill) : retourne .causal ou .array selon le cas
-        let globalMask = MLXLMCommon.createAttentionMask(
+        var globalMask = MLXLMCommon.createAttentionMask(
             h: h,
             cache: firstFullCacheIdx < cacheArray.count ? cacheArray[firstFullCacheIdx] : nil
         )
-        let slidingWindowMask = MLXLMCommon.createAttentionMask(
+        var slidingWindowMask = MLXLMCommon.createAttentionMask(
             h: h,
             cache: firstSlidingCacheIdx < cacheArray.count ? cacheArray[firstSlidingCacheIdx] : nil,
             windowSize: windowSize
         )
+
+        // Overlay bidirectionnel pour les blocs vision (gemma4_unified) :
+        // materialise les masques causaux + OR avec same_block.
+        let T = h.dim(1)
+        if let visionMask = visionTokenMask, T > 1 {
+            let blockIds = Gemma4BidirectionalMask.blockSequenceIds(visionMask: visionMask)
+            let overlay = Gemma4BidirectionalMask.overlay(blockSequenceIds: blockIds)
+
+            let causalGlobal = MLXLMCommon.createCausalMask(n: T, offset: 0)
+            let causalSliding = MLXLMCommon.createCausalMask(n: T, offset: 0, windowSize: windowSize)
+
+            let mergedGlobal = Gemma4BidirectionalMask.compose(causal: causalGlobal, overlay: overlay)
+            let mergedSliding = Gemma4BidirectionalMask.compose(causal: causalSliding, overlay: overlay)
+
+            globalMask = .array(mergedGlobal)
+            slidingWindowMask = .array(mergedSliding)
+        }
 
         // Forward a travers les layers — avec suivi des intermediaires pour le KV sharing
         // Ref: Python mlx-lm gemma4_text.py utilise intermediates[] + previous_kvs

--- a/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
+++ b/Sources/Gemma4Swift/TextModel/Gemma4TextModel.swift
@@ -173,13 +173,111 @@ public class Gemma4TextModel: Module {
         perLayerInputs: MLXArray? = nil,
         visionTokenMask: MLXArray? = nil
     ) -> MLXArray {
-        forwardCollectingIntermediates(
+        // Fast path : modeles SANS KV-sharing (12B Unified, 31B). Bypass la
+        // collecte d'intermediates qui retient ~150 MB de K/V refs par forward
+        // et augmente la pression memoire pendant le prefill.
+        // Pour E2B/E4B (avec KV-sharing), on garde le path complet.
+        if firstKvSharedLayerIdx >= numHiddenLayers {
+            return forwardWithoutIntermediates(
+                inputs: inputs,
+                inputsEmbeds: inputsEmbeds,
+                cache: cache,
+                perLayerInputs: perLayerInputs,
+                visionTokenMask: visionTokenMask
+            )
+        }
+        return forwardCollectingIntermediates(
             inputs: inputs,
             inputsEmbeds: inputsEmbeds,
             cache: cache,
             perLayerInputs: perLayerInputs,
             visionTokenMask: visionTokenMask
         ).hidden
+    }
+
+    /// Forward optimise pour les modeles SANS KV-sharing.
+    /// Identique a forwardCollectingIntermediates() mais ne stocke pas les
+    /// K/V intermediaires (pas d'array `intermediates[]`, pas de
+    /// `publicIntermediates`, pas de struct TextForwardOutput a wrapper).
+    ///
+    /// Ne pas utiliser sur E2B/E4B (KV-sharing necessite les intermediates).
+    private func forwardWithoutIntermediates(
+        inputs: MLXArray? = nil,
+        inputsEmbeds: MLXArray? = nil,
+        cache: [KVCache?]? = nil,
+        perLayerInputs: MLXArray? = nil,
+        visionTokenMask: MLXArray? = nil
+    ) -> MLXArray {
+        var h: MLXArray
+        if let inputsEmbeds = inputsEmbeds {
+            h = inputsEmbeds
+        } else if let inputs = inputs {
+            h = embedTokens(inputs)
+            h = h * MLXArray(embedScale, dtype: h.dtype)
+        } else {
+            fatalError("inputs ou inputsEmbeds requis")
+        }
+
+        var finalPerLayerInputs: MLXArray? = nil
+        if hiddenSizePerLayerInput > 0 {
+            var pli = perLayerInputs
+            if inputs != nil && pli == nil {
+                pli = getPerLayerInputs(inputs!)
+            }
+            if pli != nil || inputs != nil {
+                finalPerLayerInputs = projectPerLayerInputs(h, perLayerInputs: pli)
+            }
+        }
+
+        let cacheArray = cache ?? Array(repeating: nil as KVCache?, count: firstKvSharedLayerIdx)
+
+        var globalMask = MLXLMCommon.createAttentionMask(
+            h: h,
+            cache: firstFullCacheIdx < cacheArray.count ? cacheArray[firstFullCacheIdx] : nil
+        )
+        var slidingWindowMask = MLXLMCommon.createAttentionMask(
+            h: h,
+            cache: firstSlidingCacheIdx < cacheArray.count ? cacheArray[firstSlidingCacheIdx] : nil,
+            windowSize: windowSize
+        )
+
+        let T = h.dim(1)
+        if let visionMask = visionTokenMask, T > 1 {
+            let blockIds = Gemma4BidirectionalMask.blockSequenceIds(visionMask: visionMask)
+            let overlay = Gemma4BidirectionalMask.overlay(blockSequenceIds: blockIds)
+            let causalGlobal = MLXLMCommon.createCausalMask(n: T, offset: 0)
+            let causalSliding = MLXLMCommon.createCausalMask(n: T, offset: 0, windowSize: windowSize)
+            let mergedGlobal = Gemma4BidirectionalMask.compose(causal: causalGlobal, overlay: overlay)
+            let mergedSliding = Gemma4BidirectionalMask.compose(causal: causalSliding, overlay: overlay)
+            globalMask = .array(mergedGlobal)
+            slidingWindowMask = .array(mergedSliding)
+        }
+
+        let layerTypes = config.resolvedLayerTypes
+
+        for (i, layer) in layers.enumerated() {
+            let cacheIdx = layerIdxToCacheIdx[i]
+            let c = cacheIdx < cacheArray.count ? cacheArray[cacheIdx] : nil
+            let isGlobal = layerTypes[i] == "full_attention"
+            let localMask = isGlobal ? globalMask : slidingWindowMask
+
+            let perLayerInput: MLXArray?
+            if let fpli = finalPerLayerInputs {
+                perLayerInput = fpli[0..., 0..., i, 0...]
+            } else {
+                perLayerInput = nil
+            }
+
+            // Pas de KV-sharing : on jette les K/V retournes par la couche
+            // (le cache les a deja stockes pour ses propres besoins).
+            let (output, _, _) = layer(
+                h, mask: localMask, cache: c, perLayerInput: perLayerInput,
+                sharedKV: nil, sharedOffset: nil
+            )
+            h = output
+        }
+
+        return norm(h)
     }
 
     /// Variante de `callAsFunction` qui retourne aussi les K/V intermediaires

--- a/Sources/Gemma4Swift/Utils/WeightSanitizer.swift
+++ b/Sources/Gemma4Swift/Utils/WeightSanitizer.swift
@@ -40,10 +40,12 @@ public enum WeightSanitizer {
             if key.contains(".rope.") && key.hasSuffix(".freqs") { continue }
 
             // Skip audio si pas d'audio tower
-            if !hasAudio && (key.contains("audio_tower") || key.contains("embed_audio")) { continue }
+            if !hasAudio && (key.contains("audio_tower") || key.contains("embed_audio") || key.contains("audio_embedder")) { continue }
 
             // Skip vision si pas de vision tower
-            if !hasVision && (key.contains("vision_tower") || key.contains("embed_vision")) { continue }
+            // gemma4_unified ajoute un prefixe "vision_embedder.*" (patch embedder
+            // direct, sans SigLIP) en plus de "vision_tower" / "embed_vision".
+            if !hasVision && (key.contains("vision_tower") || key.contains("embed_vision") || key.contains("vision_embedder")) { continue }
 
             var newKey = key
             var newValue = value

--- a/Sources/Gemma4Swift/VisionEncoder/Gemma4UnifiedVisionEmbedder.swift
+++ b/Sources/Gemma4Swift/VisionEncoder/Gemma4UnifiedVisionEmbedder.swift
@@ -1,0 +1,90 @@
+// Vision embedder encoder-free pour gemma4_unified.
+//
+// Architecture (sans transformer) :
+//   pixel_patches [B, N, patchDim] (patchDim = 48*48*3)
+//   -> patch_ln1  (LayerNorm sur patchDim)
+//   -> patch_dense (Linear patchDim -> mmEmbedDim, bias=True)
+//   -> patch_ln2  (LayerNorm sur mmEmbedDim)
+//   -> + pos_embedding[x_idx, 0] + pos_embedding[y_idx, 1]  (additif si position_ids fournis)
+//   -> pos_norm  (LayerNorm)
+//
+// Port direct du VisionEmbedder Python mlx-vlm/gemma4_unified.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Encoder-free patch embedder (Gemma 4 Unified 12B).
+public class Gemma4UnifiedVisionEmbedder: Module {
+    public let config: Gemma4UnifiedVisionConfig
+    public let patchDim: Int
+
+    @ModuleInfo(key: "patch_ln1") var patchLN1: LayerNorm
+    @ModuleInfo(key: "patch_dense") var patchDense: Linear
+    @ModuleInfo(key: "patch_ln2") var patchLN2: LayerNorm
+    @ModuleInfo(key: "pos_norm") var posNorm: LayerNorm
+
+    /// pos_embedding shape : [mmPosembSize, 2, mmEmbedDim].
+    /// Axe 1 : 0 = embedding x, 1 = embedding y.
+    @ParameterInfo(key: "pos_embedding") var posEmbedding: MLXArray
+
+    public init(_ config: Gemma4UnifiedVisionConfig) {
+        self.config = config
+        self.patchDim = config.patchDim
+
+        self._patchLN1.wrappedValue = LayerNorm(dimensions: patchDim)
+        self._patchDense.wrappedValue = Linear(patchDim, config.mmEmbedDim, bias: true)
+        self._patchLN2.wrappedValue = LayerNorm(dimensions: config.mmEmbedDim)
+        self._posNorm.wrappedValue = LayerNorm(dimensions: config.mmEmbedDim)
+        self._posEmbedding.wrappedValue = MLXArray.zeros(
+            [config.mmPosembSize, 2, config.mmEmbedDim]
+        )
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - pixelValues : [B, N, patchDim] (patches flattenes) OU [B, N, _, patchDim] qui sera reshape.
+    ///   - imagePositionIds : [B, N, 2] (x_idx, y_idx) avec -1 pour padding. nil = pas de pos embedding.
+    /// - Returns: [B, N, mmEmbedDim]
+    public func callAsFunction(
+        _ pixelValues: MLXArray,
+        imagePositionIds: MLXArray? = nil
+    ) -> MLXArray {
+        // Accept [B, ?, ?, patchDim] et flatten en [B, N, patchDim]
+        var x = pixelValues
+        if x.ndim == 4 && x.dim(-1) == patchDim {
+            x = x.reshaped(x.dim(0), -1, patchDim)
+        }
+
+        var hidden = patchLN1(x)
+        hidden = patchDense(hidden)
+        hidden = patchLN2(hidden)
+
+        if let posIds = imagePositionIds {
+            // clamped = max(posIds, 0).int32() ; valid = (posIds != -1).dtype(hidden)
+            let clamped = maximum(posIds, MLXArray(Int32(0))).asType(.int32)
+            let valid = (posIds .!= MLXArray(Int32(-1))).asType(hidden.dtype)
+
+            // x_pos = pos_embedding[clamped[..., 0], 0]  -> [B, N, mmEmbedDim]
+            // y_pos = pos_embedding[clamped[..., 1], 1]
+            let xIdx = clamped[.ellipsis, 0]
+            let yIdx = clamped[.ellipsis, 1]
+
+            // pos_embedding [P, 2, D] -> [P, D] pour axe x ou y.
+            let xLookup = posEmbedding[0..., 0]  // [P, D]
+            let yLookup = posEmbedding[0..., 1]  // [P, D]
+
+            // Gather sur axe 0 : prend xLookup[xIdx[b,n]] -> [B, N, D]
+            let xPos = xLookup.take(xIdx, axis: 0)
+            let yPos = yLookup.take(yIdx, axis: 0)
+
+            // valid shape [B, N, 2]; mask sur axe -1.
+            let validX = expandedDimensions(valid[.ellipsis, 0], axis: -1)
+            let validY = expandedDimensions(valid[.ellipsis, 1], axis: -1)
+
+            hidden = hidden + (xPos * validX + yPos * validY)
+        }
+
+        return posNorm(hidden)
+    }
+}

--- a/Tests/Gemma4SwiftTests/ModelRegistryTests.swift
+++ b/Tests/Gemma4SwiftTests/ModelRegistryTests.swift
@@ -89,9 +89,10 @@ struct ModelRegistryTests {
         #expect(Gemma4Pipeline.Model.e4b4bit.estimatedSizeGB < Gemma4Pipeline.Model.a4b4bit.estimatedSizeGB)
     }
 
-    @Test("16 modeles au total (4 familles x 4 quantisations)")
+    @Test("20 modeles au total (5 familles x 4 quantisations)")
     func testModelCount() {
-        #expect(Gemma4Pipeline.Model.allCases.count == 16)
+        // 5 familles : E2B, E4B, 31B, 26B-A4B, 12B Unified ; 4 quants chacune.
+        #expect(Gemma4Pipeline.Model.allCases.count == 20)
     }
 
     @Test("Raw values sont des IDs HuggingFace valides")

--- a/Tests/Gemma4SwiftTests/TurboQuantViabilityTests.swift
+++ b/Tests/Gemma4SwiftTests/TurboQuantViabilityTests.swift
@@ -1,0 +1,117 @@
+// Tests de regression sur turboQuantViable() : le compte de KV heads doit
+// utiliser num_global_key_value_heads sur les modeles MQA full attention
+// (ex: 12B Unified), sinon on surestime massivement le gain et active TQ
+// alors qu'il est COUTeux en perf et n'economise quasi rien.
+
+import Testing
+import Foundation
+@testable import Gemma4Swift
+
+@Suite("TurboQuant Viability — heuristique gain RAM")
+struct TurboQuantViabilityTests {
+
+    /// Construit un TextConfig minimaliste depuis un dict JSON, en partant
+    /// d'un squelette commun.
+    private static func textConfig(json: String) throws -> Gemma4TextConfig {
+        let data = json.data(using: .utf8)!
+        return try JSONDecoder().decode(Gemma4TextConfig.self, from: data)
+    }
+
+    @Test("12B Unified (MQA kv_heads=1, head_dim=512, 8 full_attn) — TQ4 doit etre desactive")
+    func test12BMQADisabled() throws {
+        // Pattern : 5 sliding + 1 full repete 8 fois = 48 layers, 8 full_attn.
+        var pattern: [String] = []
+        for _ in 0..<8 { pattern.append(contentsOf: Array(repeating: "sliding_attention", count: 5) + ["full_attention"]) }
+        let layerTypesJson = pattern.map { "\"\($0)\"" }.joined(separator: ",")
+
+        let json = """
+        {
+            "model_type": "gemma4_unified_text",
+            "hidden_size": 3840,
+            "num_hidden_layers": 48,
+            "intermediate_size": 15360,
+            "num_attention_heads": 16,
+            "head_dim": 256,
+            "global_head_dim": 512,
+            "vocab_size": 262144,
+            "num_key_value_heads": 8,
+            "num_global_key_value_heads": 1,
+            "num_kv_shared_layers": 0,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 1024,
+            "max_position_embeddings": 131072,
+            "attention_k_eq_v": true,
+            "layer_types": [\(layerTypesJson)],
+            "tie_word_embeddings": true
+        }
+        """
+        let cfg = try Self.textConfig(json: json)
+        let (viable, fullCount, headDim, reason) = Gemma4LanguageModel.turboQuantViability(config: cfg, bits: 4)
+        #expect(fullCount == 8)
+        #expect(headDim == 512)
+        #expect(viable == false, "12B MQA(1) full_attn ne devrait PAS passer le check : \(reason)")
+        #expect(reason.contains("kv_heads=1"))
+    }
+
+    @Test("Hypothetique GQA kv_heads=8 sur full_attn — TQ4 doit etre active")
+    func testGQA8HeadsEnabled() throws {
+        // Meme pattern que 12B mais sans MQA : attention_k_eq_v=false (kv_heads=8 sur full).
+        var pattern: [String] = []
+        for _ in 0..<8 { pattern.append(contentsOf: Array(repeating: "sliding_attention", count: 5) + ["full_attention"]) }
+        let layerTypesJson = pattern.map { "\"\($0)\"" }.joined(separator: ",")
+
+        let json = """
+        {
+            "model_type": "gemma4_text",
+            "hidden_size": 3840,
+            "num_hidden_layers": 48,
+            "intermediate_size": 15360,
+            "num_attention_heads": 16,
+            "head_dim": 256,
+            "global_head_dim": 512,
+            "vocab_size": 262144,
+            "num_key_value_heads": 8,
+            "num_kv_shared_layers": 0,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 1024,
+            "max_position_embeddings": 131072,
+            "attention_k_eq_v": false,
+            "layer_types": [\(layerTypesJson)],
+            "tie_word_embeddings": true
+        }
+        """
+        let cfg = try Self.textConfig(json: json)
+        let (viable, _, _, reason) = Gemma4LanguageModel.turboQuantViability(config: cfg, bits: 4)
+        #expect(viable == true, "8 KV heads sur full_attn => gain large, devrait etre actif : \(reason)")
+        #expect(reason.contains("kv_heads=8"))
+    }
+
+    @Test("Modele a 0 full_attn — TQ desactive avec raison explicite")
+    func testNoFullAttnDisabled() throws {
+        let json = """
+        {
+            "model_type": "gemma4_text",
+            "hidden_size": 2048,
+            "num_hidden_layers": 20,
+            "intermediate_size": 8192,
+            "num_attention_heads": 8,
+            "head_dim": 256,
+            "global_head_dim": 0,
+            "vocab_size": 262144,
+            "num_key_value_heads": 4,
+            "num_kv_shared_layers": 0,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 1024,
+            "max_position_embeddings": 131072,
+            "attention_k_eq_v": false,
+            "layer_types": ["sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention","sliding_attention"],
+            "tie_word_embeddings": true
+        }
+        """
+        let cfg = try Self.textConfig(json: json)
+        let (viable, fullCount, _, reason) = Gemma4LanguageModel.turboQuantViability(config: cfg, bits: 4)
+        #expect(fullCount == 0)
+        #expect(viable == false)
+        #expect(reason.contains("trop peu de couches full attention"))
+    }
+}


### PR DESCRIPTION
## Summary

- **Port complet du modèle `gemma4_unified` (Gemma 4 12B)** : text + image + audio + vidéo, avec bidirectional attention sur les blocs vision (gain qualité majeur — descriptions précises au lieu d'hallucinations)
- **Quantification à la volée** (`--quantize-bits N`) : permet de benchmarker 4/6/8-bit affine à partir d'un seul checkpoint bf16, économise 50+ Go de downloads pré-quantisés par famille
- **ProportionalRoPE simplifiée** (1 seul `MLXFast.RoPE` avec freqs paddées +inf au lieu de 6 slice/concat — gain ~2-3%)

## Détails par axe

### 1. Port `gemma4_unified` (12B)

Architecture radicalement plus simple qu'E2B/E4B côté multimodal :

- **Vision encoder-free** : pas de SigLIP. Patch projector `LN(6912) → Linear(6912→3840) → LN → +pos_embedding(x,y) → LN`. Patches 48×48.
- **Audio sans Conformer** : projection directe de chunks PCM bruts de 640 samples (40 ms à 16 kHz).
- **MQA full-attention** : `num_global_kv_heads=1` + `attention_k_eq_v=true` (V partage K). Déjà supporté par le code existant.
- **48 layers, hidden 3840, head_dim 256/512, sliding window 1024**.

Nouveaux fichiers :
- `Configuration/Gemma4UnifiedConfig.swift` (+ Vision/Audio configs)
- `VisionEncoder/Gemma4UnifiedVisionEmbedder.swift`
- `Pipeline/Gemma4UnifiedMultimodalLLMModel.swift`
- `Pipeline/Gemma4UnifiedImageProcessor.swift` (resize aspect-ratio preserving + patches 48×48 + position IDs)
- `Pipeline/Gemma4UnifiedAudioProcessor.swift` (waveform → chunks 640)
- `Pipeline/Gemma4UnifiedVideoProcessor.swift` (frames → patches per-frame)
- `TextModel/Gemma4BidirectionalMask.swift` (block_sequence_ids + same_block overlay)

### 2. Bidirectional vision attention (`use_bidirectional_attention="vision"`)

Sans ce mask :
- Image coureurs (F&M TRACK CLUB visible) → hallucine "ASICS TRAXXON"
- Image départ marathon (SPAR banners, bibs CAELIN/WELMA) → invente "RUNNING FOR LIFE", "S.T.A.R.S."

Avec ce mask :
- Lit correctement "F&M TRACK CLUB", "START", "SPAR", "CAELIN", "WELMA"

Implémentation : `Gemma4TextModel.forwardCollectingIntermediates(visionTokenMask:)` matérialise les masques causaux (global + sliding) puis les fusionne par OR avec le same_block overlay quand T>1 et qu'on est dans un bloc vision sans audio.

### 3. Quantification à la volée

`Gemma4OnTheFlyQuantization.apply(to:bits:groupSize:mode:excludedPathPrefixes:)` applique `MLXNN.quantize(model:filter:apply:)` après le load.

Flags CLI sur `generate`, `describe`, `profile run` :
- `--quantize-bits N` (4 | 6 | 8)
- `--quantize-group-size G` (default 64, auto-corrigé à 32 pour mxfp4/8)
- `--quantize-mode M` (affine | mxfp4 | mxfp8)
- `--quantize-text-only` (préserve `vision_embedder/embed_vision/embed_audio/vision_tower/audio_tower` en bf16)

**Défaut = quantize tout** (cohérent avec pré-quant mlx-community qui quantise aussi `patch_dense` etc).

### 4. ProportionalRoPE simplifié

Avant : split left/right → extract rotated portions → concat → RoPE → split → recombine. 6 ops tensor par appel.

Après : un seul `MLXFast.RoPE` avec freqs paddées de `+inf` sur les dimensions non-rotées (sin/cos d'inf → identité, astuce du code Python mlx-lm).

## Résultats benchmarks (M4 Max, 96 GB RAM)

### 12B-bf16 → OTF (à partir du même checkpoint bf16)

| Config | t/s | RAM MLX | Δ vs bf16 |
|---|---|---|---|
| bf16 natif | 11.3 | 22.8 GB | — |
| OTF 8-bit | 19.7 | 12.2 GB | 1.74× |
| OTF 6-bit | 24.3 | 9.4 GB | 2.15× |
| **OTF 4-bit** | **33.4** | **6.5 GB** | **2.97×** |
| Pre-quant mlx-community 4-bit (mix 4/8) | 22.5 | 10.6 GB | 2.00× |

Le pré-quant mlx-community est en réalité un mix 4-bit (attention) + 8-bit (MLP). L'OTF 4-bit pure est plus rapide ET plus économe en RAM.

### E2B-bf16 → OTF

| Config | t/s | RAM MLX |
|---|---|---|
| bf16 natif | 46.5 | 8.9 GB |
| OTF 8-bit | 74.6 | 4.7 GB |
| OTF 6-bit | 86.2 | 3.6 GB |
| **OTF 4-bit** | **105** | **2.5 GB** |

### Parité Python mlx-vlm

12B-4bit pre-quant : **Swift 22.4 t/s vs Python mlx-vlm 21.5 t/s** → pas de problème de performance framework.

## Test plan

- [x] `swift test` passe (test `testModelCount` mis à jour 16 → 20)
- [x] Build `xcodebuild -scheme gemma4-cli` clean
- [x] `gemma4-cli generate` sur 12B-4bit (Paris ✓)
- [x] `gemma4-cli describe --image` sur 12B-4bit (description précise avec bidir ✓)
- [x] `gemma4-cli describe --audio` sur 12B-4bit (compréhension correcte ✓)
- [x] `gemma4-cli describe --video` sur 12B-4bit (26 frames, description cohérente ✓)
- [x] Multi-image + image+audio combinés
- [x] OTF 4-bit qualité validée sur math, code, traduction, multimodal
- [x] Régression E2B `generate` + `describe --image/--audio` (intact)
- [ ] CI à valider

## Limites résiduelles connues

- **mxfp4 / mxfp8** : échoue (`scales must be uint8`). Constraint MLX kernel — nécessite path d'init différent, à creuser dans un suivi
- **MTP drafter pas porté pour 12B** : pas de checkpoint Assistant publié pour 12B Unified
- **E4B / 31B / 26B-A4B non re-testés en describe multimodal** après les changements (les tests CI couvrent uniquement le path text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)